### PR TITLE
Add clustered venue map markers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,11 @@ jobs:
   build-node:
     executor: node-executor
     steps:
-      - checkout
+      - run:
+          name: Checkout source
+          command: |
+            git clone --blobless https://github.com/jbiddulph/johnpyfe.git .
+            git checkout "$CIRCLE_SHA1"
       - run:
           name: Install dependencies
           command: npm install
@@ -28,7 +32,11 @@ jobs:
   test:
     executor: node-executor
     steps:
-      - checkout
+      - run:
+          name: Checkout source
+          command: |
+            git clone --blobless https://github.com/jbiddulph/johnpyfe.git .
+            git checkout "$CIRCLE_SHA1"
       - run:
           name: Install dependencies
           command: npm install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - run:
           name: Checkout source
           command: |
-            git clone --blobless https://github.com/jbiddulph/johnpyfe.git .
+            git clone --filter=blob:none https://github.com/jbiddulph/johnpyfe.git .
             git checkout "$CIRCLE_SHA1"
       - run:
           name: Install dependencies
@@ -35,7 +35,7 @@ jobs:
       - run:
           name: Checkout source
           command: |
-            git clone --blobless https://github.com/jbiddulph/johnpyfe.git .
+            git clone --filter=blob:none https://github.com/jbiddulph/johnpyfe.git .
             git checkout "$CIRCLE_SHA1"
       - run:
           name: Install dependencies

--- a/components/home/HomeRankedList.vue
+++ b/components/home/HomeRankedList.vue
@@ -14,10 +14,18 @@
           class="home-ranked-photo block overflow-hidden rounded-lg shadow-sm transition-transform hover:-translate-y-0.5"
         >
           <div
-            class="home-ranked-photo__media relative min-h-[140px] bg-cover bg-center"
-            :class="{ 'home-ranked-photo__media--fallback': !item.imageUrl }"
-            :style="photoStyle(item)"
+            class="home-ranked-photo__media relative min-h-[140px] overflow-hidden"
+            :class="{ 'home-ranked-photo__media--fallback': !hasUsableImage(item, index) }"
           >
+            <img
+              v-if="hasUsableImage(item, index)"
+              :src="item.imageUrl || ''"
+              :alt="imageAlt(item)"
+              class="absolute inset-0 h-full w-full object-cover"
+              loading="lazy"
+              decoding="async"
+              @error="markImageFailed(item, index)"
+            >
             <div class="home-ranked-photo__overlay" aria-hidden="true" />
             <div class="home-ranked-photo__content relative z-[1] flex min-h-[140px] flex-col justify-end p-4 text-white">
               <span class="home-ranked__rank home-ranked__rank--photo mb-2 w-fit" aria-hidden="true">
@@ -62,6 +70,7 @@ export type HomeRankedItem = {
   slug?: string
   imageUrl?: string | null
   imageAttribution?: string | null
+  imageAlt?: string | null
 }
 
 const props = withDefaults(
@@ -82,8 +91,24 @@ function itemKey(item: HomeRankedItem, index: number) {
   return item.slug || item.href || `${item.displayName}-${index}`
 }
 
-function photoStyle(item: HomeRankedItem) {
-  return item.imageUrl ? { backgroundImage: `url('${item.imageUrl}')` } : undefined
+const failedImageKeys = ref(new Set<string>())
+
+function imageKey(item: HomeRankedItem, index: number) {
+  return item.imageUrl || itemKey(item, index)
+}
+
+function hasUsableImage(item: HomeRankedItem, index: number) {
+  return Boolean(item.imageUrl) && !failedImageKeys.value.has(imageKey(item, index))
+}
+
+function markImageFailed(item: HomeRankedItem, index: number) {
+  const nextFailedImageKeys = new Set(failedImageKeys.value)
+  nextFailedImageKeys.add(imageKey(item, index))
+  failedImageKeys.value = nextFailedImageKeys
+}
+
+function imageAlt(item: HomeRankedItem) {
+  return item.imageAlt || (item.meta ? `${item.displayName} - ${item.meta}` : item.displayName)
 }
 </script>
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -84,6 +84,7 @@ const stadiumListItems = computed(() =>
     slug: s.slug,
     imageUrl: s.imageUrl,
     imageAttribution: s.imageAttribution,
+    imageAlt: `${s.stadiumName}, home of ${s.club}`,
   })),
 )
 

--- a/pages/map/index.vue
+++ b/pages/map/index.vue
@@ -40,7 +40,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, onMounted, watch, computed } from 'vue'
+import { ref, reactive, onMounted, computed } from 'vue'
 import { useVenueStore } from '@/store/venue.js'
 import { useEventStore } from '@/store/event.js'
 
@@ -70,10 +70,29 @@ const isOpenLeft = reactive({
 const venueName = ref('VENUES')
 const map = ref<any>(null)
 const mapError = ref('')
+const mapVenues = ref<MapVenuePoint[]>([])
 let mapboxgl: typeof import('mapbox-gl').default | null = null
 let popup: InstanceType<typeof import('mapbox-gl').default.Popup> | null = null
 let popupTimeout: ReturnType<typeof setTimeout> | null = null
-const layersAdded = ref<string[]>([])
+const hiddenLegacyLayerIds = ref(new Set<string>())
+
+const SOURCE_ID = 'venue-clusters'
+const LAYER_CLUSTERS = 'venue-clusters-circle'
+const LAYER_CLUSTER_COUNT = 'venue-clusters-count'
+const LAYER_UNCLUSTERED = 'venue-unclustered-point'
+
+type MapVenuePoint = {
+  id: number
+  fsa_id: number
+  slug: string
+  venuename: string
+  address?: string | null
+  address2?: string | null
+  town?: string | null
+  county?: string | null
+  latitude: string
+  longitude: string
+}
 
 onMounted(async () => {
   eventStore.fetchCities()
@@ -112,7 +131,12 @@ async function createMap() {
 
   try {
     const order = '-venue_count'
-    await Promise.all([venueStore.fetchTowns(), venueStore.fetchNames(order)])
+    const [, , venuePoints] = await Promise.all([
+      venueStore.fetchTowns(),
+      venueStore.fetchNames(order),
+      $fetch<MapVenuePoint[]>('/api/venues/map'),
+    ])
+    mapVenues.value = venuePoints
 
     mapboxgl = (await import('mapbox-gl')).default
     mapboxgl.accessToken = mapboxToken.value
@@ -136,6 +160,8 @@ async function createMap() {
 
     map.value.on('load', () => {
       map.value.resize()
+      ensureClusterLayers()
+      bindClusterHandlers()
       updateMapLayer(venueName.value)
     })
   } catch (err) {
@@ -151,46 +177,226 @@ function updateMapLayer(layerId: string) {
     return
   }
 
-  layersAdded.value.forEach((id) => {
+  hideLegacyVenueLayers(layerId)
+
+  const source = map.value.getSource(SOURCE_ID)
+  source?.setData(buildVenueGeoJson(filteredVenuePoints(layerId)))
+}
+
+function hideLegacyVenueLayers(activeLayerId: string) {
+  if (!map.value) return
+
+  const legacyLayerIds = new Set([
+    'VENUES',
+    activeLayerId,
+    ...Array.from(hiddenLegacyLayerIds.value),
+  ])
+
+  for (const id of legacyLayerIds) {
     if (map.value.getLayer(id)) {
       map.value.setLayoutProperty(id, 'visibility', 'none')
+      hiddenLegacyLayerIds.value.add(id)
     }
+  }
+}
+
+function filteredVenuePoints(layerId: string) {
+  const selected = layerId.trim().toUpperCase()
+  if (!selected || selected === 'VENUES') return mapVenues.value
+
+  return mapVenues.value.filter((venue) => venue.venuename?.toUpperCase() === selected)
+}
+
+function parseCoord(value: string | number | null | undefined) {
+  const n = Number(value)
+  return Number.isFinite(n) && n !== 0 ? n : null
+}
+
+function buildVenueGeoJson(venues: MapVenuePoint[]) {
+  return {
+    type: 'FeatureCollection' as const,
+    features: venues
+      .map((venue) => {
+        const lat = parseCoord(venue.latitude)
+        const lng = parseCoord(venue.longitude)
+        if (lat == null || lng == null) return null
+
+        return {
+          type: 'Feature' as const,
+          geometry: {
+            type: 'Point' as const,
+            coordinates: [lng, lat],
+          },
+          properties: {
+            id: venue.id,
+            fsa_id: venue.fsa_id,
+            venuename: venue.venuename,
+            address: venue.address || '',
+            address2: venue.address2 || '',
+            town: venue.town || '',
+            county: venue.county || '',
+          },
+        }
+      })
+      .filter(Boolean),
+  }
+}
+
+function ensureClusterLayers() {
+  if (!map.value || map.value.getSource(SOURCE_ID)) return
+
+  map.value.addSource(SOURCE_ID, {
+    type: 'geojson',
+    data: buildVenueGeoJson([]),
+    cluster: true,
+    clusterMaxZoom: 13,
+    clusterRadius: 56,
   })
 
-  if (map.value.getLayer(layerId)) {
-    map.value.setLayoutProperty(layerId, 'visibility', 'visible')
-    layersAdded.value.push(layerId)
-  }
+  map.value.addLayer({
+    id: LAYER_CLUSTERS,
+    type: 'circle',
+    source: SOURCE_ID,
+    filter: ['has', 'point_count'],
+    paint: {
+      'circle-color': [
+        'step',
+        ['get', 'point_count'],
+        '#f59e0b',
+        25,
+        '#d97706',
+        100,
+        '#b45309',
+        500,
+        '#92400e',
+      ],
+      'circle-radius': [
+        'step',
+        ['get', 'point_count'],
+        18,
+        25,
+        23,
+        100,
+        29,
+        500,
+        36,
+      ],
+      'circle-stroke-width': 2,
+      'circle-stroke-color': '#ffffff',
+      'circle-opacity': 0.95,
+    },
+  })
 
-  map.value.off('mouseenter', layerId)
-  map.value.off('mouseleave', layerId)
-  map.value.off('click', layerId)
+  map.value.addLayer({
+    id: LAYER_CLUSTER_COUNT,
+    type: 'symbol',
+    source: SOURCE_ID,
+    filter: ['has', 'point_count'],
+    layout: {
+      'text-field': ['get', 'point_count_abbreviated'],
+      'text-font': ['Open Sans Semibold', 'Arial Unicode MS Bold'],
+      'text-size': 12,
+    },
+    paint: {
+      'text-color': '#ffffff',
+    },
+  })
 
-  map.value.on('mouseenter', layerId, (e: { features: any[] }) => {
-    if (!mapboxgl) return
+  map.value.addLayer({
+    id: LAYER_UNCLUSTERED,
+    type: 'circle',
+    source: SOURCE_ID,
+    filter: ['!', ['has', 'point_count']],
+    paint: {
+      'circle-color': '#d97706',
+      'circle-radius': [
+        'interpolate',
+        ['linear'],
+        ['zoom'],
+        5,
+        5,
+        12,
+        7,
+        16,
+        9,
+      ],
+      'circle-stroke-width': 2,
+      'circle-stroke-color': '#ffffff',
+      'circle-opacity': 1,
+    },
+  })
+}
+
+function bindClusterHandlers() {
+  if (!map.value || !mapboxgl) return
+
+  map.value.on('click', LAYER_CLUSTERS, (e: { point: unknown }) => {
+    const features = map.value.queryRenderedFeatures(e.point, { layers: [LAYER_CLUSTERS] })
+    if (!features.length) return
+
+    const clusterId = features[0].properties?.cluster_id
+    const source = map.value.getSource(SOURCE_ID)
+    if (!source || clusterId == null) return
+
+    source.getClusterExpansionZoom(clusterId, (err: Error | null, zoom: number) => {
+      if (err) return
+      map.value.easeTo({
+        center: features[0].geometry.coordinates,
+        zoom,
+      })
+    })
+  })
+
+  map.value.on('mouseenter', LAYER_UNCLUSTERED, (e: { features: any[] }) => {
+    if (popupTimeout) clearTimeout(popupTimeout)
     const feature = e.features[0]
+    if (!feature) return
+
     const coordinates = feature.geometry.coordinates.slice()
+    const { venuename, address, address2, town, county } = feature.properties
+    const addressParts = [address, address2, town, county].filter(Boolean)
+
     popup = new mapboxgl.Popup({ closeButton: false })
       .setLngLat(coordinates)
       .setHTML(
-        `<div class='p-2'><h1 class='mb-4 text-2xl'>${feature.properties.venuename}</h1> <h2>${feature.properties.address}, ${feature.properties.address2}</h2></div>`,
+        `<div class="p-2"><h1 class="mb-2 text-lg font-semibold">${escapeHtml(venuename)}</h1><div>${escapeHtml(addressParts.join(', '))}</div></div>`,
       )
       .addTo(map.value)
   })
 
-  map.value.on('mouseleave', layerId, () => {
+  map.value.on('mouseleave', LAYER_UNCLUSTERED, () => {
     popupTimeout = setTimeout(() => {
       popup?.remove()
       popup = null
-    }, 1000)
+    }, 500)
   })
 
-  map.value.on('click', layerId, (e: { features: { properties: { fsa_id: unknown } }[] }) => {
+  map.value.on('click', LAYER_UNCLUSTERED, (e: { features: { properties: { fsa_id: unknown } }[] }) => {
     popup?.remove()
     popup = null
     isOpenRight.slideover = true
     isOpenRight.featureId = e.features[0].properties.fsa_id as string | number
   })
+
+  const setPointer = () => {
+    map.value.getCanvas().style.cursor = 'pointer'
+  }
+  const clearPointer = () => {
+    map.value.getCanvas().style.cursor = ''
+  }
+
+  for (const layerId of [LAYER_CLUSTERS, LAYER_UNCLUSTERED]) {
+    map.value.on('mouseenter', layerId, setPointer)
+    map.value.on('mouseleave', layerId, clearPointer)
+  }
+}
+
+function escapeHtml(text: unknown) {
+  return String(text ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
 }
 
 onBeforeUnmount(() => {

--- a/server/api/homepage/stats.get.ts
+++ b/server/api/homepage/stats.get.ts
@@ -5,7 +5,7 @@ let cached: Awaited<ReturnType<typeof getHomepageStats>> | null = null
 let cacheExpiresAt = 0
 const CACHE_MS = 60 * 60 * 1000
 /** Bump when homepage aggregation logic changes (invalidates in-memory cache). */
-const CACHE_VERSION = 5
+const CACHE_VERSION = 6
 let cacheVersion = 0
 
 /** Aggregated homepage discovery lists (cached 1 hour). */

--- a/server/api/venues/map.get.ts
+++ b/server/api/venues/map.get.ts
@@ -3,8 +3,12 @@ import { cleanDbString, slugifyPlace } from '../../../utils/format-venue'
 
 type MapVenueRow = {
   id: number
+  fsa_id: number
   slug: string
   venuename: string
+  address: string
+  address2: string
+  town: string
   county: string
   latitude: string
   longitude: string
@@ -12,8 +16,12 @@ type MapVenueRow = {
 
 type MapVenuePoint = {
   id: number
+  fsa_id: number
   slug: string
   venuename: string
+  address: string | null
+  address2: string | null
+  town: string | null
   latitude: string
   longitude: string
   county: string | null
@@ -39,8 +47,12 @@ function mapRowsToPoints(rows: MapVenueRow[]): MapVenuePoint[] {
     const countyName = cleanDbString(venue.county)
     points.push({
       id: venue.id,
+      fsa_id: venue.fsa_id,
       slug: venue.slug,
       venuename: venue.venuename,
+      address: cleanDbString(venue.address),
+      address2: cleanDbString(venue.address2),
+      town: cleanDbString(venue.town),
       latitude: String(lat),
       longitude: String(lng),
       county: countyName,
@@ -60,7 +72,7 @@ export default defineEventHandler(async (event) => {
 
   try {
     const rows = await prisma.$queryRaw<MapVenueRow[]>`
-      SELECT id, slug, venuename, county, latitude, longitude
+      SELECT id, fsa_id, slug, venuename, address, address2, town, county, latitude, longitude
       FROM "Venue"
       WHERE slug <> ''
         AND latitude IS NOT NULL


### PR DESCRIPTION
## Summary
- add clustered GeoJSON venue markers to the main map page with count bubbles and click-to-zoom clusters
- preserve individual venue click behaviour by including fsa_id and address details in the map API payload
- restore homepage photo cards with real image elements and refresh the homepage stats cache key

## Verification
- npm run build