### PR TITLE
Fix venue map API loading

### DIFF
--- a/pages/map/index.vue
+++ b/pages/map/index.vue
@@ -82,20 +82,15 @@ const LAYER_CLUSTER_COUNT = 'venue-clusters-count'
 const LAYER_UNCLUSTERED = 'venue-unclustered-point'
 
 type MapVenuePoint = {
-  id: number
-  fsa_id: number
-  slug: string
-  venuename: string
-  address?: string | null
-  address2?: string | null
-  town?: string | null
-  county?: string | null
-  latitude: string
-  longitude: string
+  fsaId: number
+  name: string
+  lat: number
+  lng: number
 }
 
 onMounted(async () => {
-  eventStore.fetchCities()
+  void eventStore.fetchCities()
+  void loadFilterData()
   await createMap()
 })
 
@@ -130,14 +125,6 @@ async function createMap() {
   }
 
   try {
-    const order = '-venue_count'
-    const [, , venuePoints] = await Promise.all([
-      venueStore.fetchTowns(),
-      venueStore.fetchNames(order),
-      $fetch<MapVenuePoint[]>('/api/venues/map'),
-    ])
-    mapVenues.value = venuePoints
-
     mapboxgl = (await import('mapbox-gl')).default
     mapboxgl.accessToken = mapboxToken.value
 
@@ -163,10 +150,28 @@ async function createMap() {
       ensureClusterLayers()
       bindClusterHandlers()
       updateMapLayer(venueName.value)
+      void loadVenueClusters()
     })
   } catch (err) {
     console.error('Failed to create map:', err)
     mapError.value = 'Unable to load the map. Please try again later.'
+  }
+}
+
+async function loadFilterData() {
+  try {
+    await Promise.all([venueStore.fetchTowns(), venueStore.fetchNames('-venue_count')])
+  } catch (err) {
+    console.error('Failed to load map filters:', err)
+  }
+}
+
+async function loadVenueClusters() {
+  try {
+    mapVenues.value = await $fetch<MapVenuePoint[]>('/api/venues/map')
+    updateMapLayer(venueName.value)
+  } catch (err) {
+    console.error('Failed to load venue clusters:', err)
   }
 }
 
@@ -204,7 +209,7 @@ function filteredVenuePoints(layerId: string) {
   const selected = layerId.trim().toUpperCase()
   if (!selected || selected === 'VENUES') return mapVenues.value
 
-  return mapVenues.value.filter((venue) => venue.venuename?.toUpperCase() === selected)
+  return mapVenues.value.filter((venue) => venue.name?.toUpperCase() === selected)
 }
 
 function parseCoord(value: string | number | null | undefined) {
@@ -217,8 +222,8 @@ function buildVenueGeoJson(venues: MapVenuePoint[]) {
     type: 'FeatureCollection' as const,
     features: venues
       .map((venue) => {
-        const lat = parseCoord(venue.latitude)
-        const lng = parseCoord(venue.longitude)
+        const lat = parseCoord(venue.lat)
+        const lng = parseCoord(venue.lng)
         if (lat == null || lng == null) return null
 
         return {
@@ -228,13 +233,8 @@ function buildVenueGeoJson(venues: MapVenuePoint[]) {
             coordinates: [lng, lat],
           },
           properties: {
-            id: venue.id,
-            fsa_id: venue.fsa_id,
-            venuename: venue.venuename,
-            address: venue.address || '',
-            address2: venue.address2 || '',
-            town: venue.town || '',
-            county: venue.county || '',
+            fsa_id: venue.fsaId,
+            venuename: venue.name,
           },
         }
       })
@@ -353,13 +353,12 @@ function bindClusterHandlers() {
     if (!feature) return
 
     const coordinates = feature.geometry.coordinates.slice()
-    const { venuename, address, address2, town, county } = feature.properties
-    const addressParts = [address, address2, town, county].filter(Boolean)
+    const { venuename } = feature.properties
 
     popup = new mapboxgl.Popup({ closeButton: false })
       .setLngLat(coordinates)
       .setHTML(
-        `<div class="p-2"><h1 class="mb-2 text-lg font-semibold">${escapeHtml(venuename)}</h1><div>${escapeHtml(addressParts.join(', '))}</div></div>`,
+        `<div class="p-2"><h1 class="text-lg font-semibold">${escapeHtml(venuename)}</h1></div>`,
       )
       .addTo(map.value)
   })

--- a/server/api/venues/map.get.ts
+++ b/server/api/venues/map.get.ts
@@ -1,31 +1,16 @@
 import { prisma } from '../../utils/prisma'
-import { cleanDbString, slugifyPlace } from '../../../utils/format-venue'
-
 type MapVenueRow = {
-  id: number
   fsa_id: number
-  slug: string
   venuename: string
-  address: string
-  address2: string
-  town: string
-  county: string
   latitude: string
   longitude: string
 }
 
 type MapVenuePoint = {
-  id: number
-  fsa_id: number
-  slug: string
-  venuename: string
-  address: string | null
-  address2: string | null
-  town: string | null
-  latitude: string
-  longitude: string
-  county: string | null
-  countySlug: string
+  fsaId: number
+  name: string
+  lat: number
+  lng: number
 }
 
 let cachedPoints: MapVenuePoint[] | null = null
@@ -44,19 +29,11 @@ function mapRowsToPoints(rows: MapVenueRow[]): MapVenuePoint[] {
     const lng = parseCoord(venue.longitude)
     if (lat == null || lng == null) continue
 
-    const countyName = cleanDbString(venue.county)
     points.push({
-      id: venue.id,
-      fsa_id: venue.fsa_id,
-      slug: venue.slug,
-      venuename: venue.venuename,
-      address: cleanDbString(venue.address),
-      address2: cleanDbString(venue.address2),
-      town: cleanDbString(venue.town),
-      latitude: String(lat),
-      longitude: String(lng),
-      county: countyName,
-      countySlug: countyName ? slugifyPlace(countyName) : '',
+      fsaId: venue.fsa_id,
+      name: venue.venuename,
+      lat,
+      lng,
     })
   }
   return points
@@ -72,7 +49,7 @@ export default defineEventHandler(async (event) => {
 
   try {
     const rows = await prisma.$queryRaw<MapVenueRow[]>`
-      SELECT id, fsa_id, slug, venuename, address, address2, town, county, latitude, longitude
+      SELECT fsa_id, venuename, latitude, longitude
       FROM "Venue"
       WHERE slug <> ''
         AND latitude IS NOT NULL

--- a/server/api/venues/map.get.ts
+++ b/server/api/venues/map.get.ts
@@ -2,8 +2,8 @@ import { prisma } from '../../utils/prisma'
 type MapVenueRow = {
   fsa_id: number
   venuename: string
-  latitude: string
-  longitude: string
+  latitude: string | null
+  longitude: string | null
 }
 
 type MapVenuePoint = {
@@ -48,19 +48,19 @@ export default defineEventHandler(async (event) => {
   }
 
   try {
-    const rows = await prisma.$queryRaw<MapVenueRow[]>`
-      SELECT fsa_id, venuename, latitude, longitude
-      FROM "Venue"
-      WHERE slug <> ''
-        AND latitude IS NOT NULL
-        AND longitude IS NOT NULL
-        AND latitude <> ''
-        AND longitude <> ''
-        AND latitude <> '0'
-        AND longitude <> '0'
-        AND latitude ~ '^-?[0-9]+(\\.[0-9]+)?$'
-        AND longitude ~ '^-?[0-9]+(\\.[0-9]+)?$'
-    `
+    const rows = await prisma.venue.findMany({
+      where: {
+        slug: { not: '' },
+        latitude: { not: '' },
+        longitude: { not: '' },
+      },
+      select: {
+        fsa_id: true,
+        venuename: true,
+        latitude: true,
+        longitude: true,
+      },
+    })
 
     cachedPoints = mapRowsToPoints(rows)
     cacheExpiresAt = Date.now() + CACHE_MS


### PR DESCRIPTION
## Summary
- avoid raw SQL regex scanning in /api/venues/map
- load venue map points through Prisma with narrow selected fields
- keep coordinate validation in application code so bad venue coordinates are skipped instead of breaking the endpoint

## Verification
- npm run build