### PR TITLE
Expand map venue details modal

### DIFF
--- a/pages/map/index.vue
+++ b/pages/map/index.vue
@@ -33,7 +33,35 @@
     </USlideover>
     <USlideover v-model="isOpenLeft.slideover" side="left">
       <div class="p-4 flex-1">
-        <venue-eventList v-if="venueStore.venue?.id" class="h-full" :venue-id="venueStore.venue.id" @close="isOpenLeft.slideover = false" />
+        <div class="mb-4 flex items-start justify-between gap-3">
+          <div>
+            <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
+              {{ selectedVenueDetails?.venuename || selectedVenue?.name || 'Venue events' }}
+            </h2>
+            <button
+              v-if="selectedVenueDetails && !isDesktopViewport"
+              type="button"
+              class="mt-1 text-sm font-medium text-amber-700 hover:text-amber-800"
+              @click="reopenVenueDetails"
+            >
+              Back to pub details
+            </button>
+          </div>
+          <UButton
+            color="gray"
+            variant="ghost"
+            icon="i-heroicons-x-mark-20-solid"
+            aria-label="Close events"
+            @click="isOpenLeft.slideover = false"
+          />
+        </div>
+        <venue-eventList
+          v-if="venueStore.venue?.id"
+          :key="venueStore.venue.id"
+          class="h-full"
+          :venue-id="venueStore.venue.id"
+          @close="isOpenLeft.slideover = false"
+        />
       </div>
     </USlideover>
     <UModal v-model="isVenueModalOpen">
@@ -51,18 +79,65 @@
             <UButton color="gray" variant="ghost" icon="i-heroicons-x-mark-20-solid" class="-my-1" @click="closeVenueModal" />
           </div>
         </template>
-        <div class="space-y-4">
-          <div class="space-y-1 text-sm text-gray-700 dark:text-gray-200">
-            <p v-for="line in selectedVenueAddressLines" :key="line">
-              {{ line }}
-            </p>
+        <div class="space-y-5">
+          <div v-if="isVenueDetailsLoading" class="text-sm text-gray-500 dark:text-gray-400">
+            Loading venue details...
           </div>
+          <UAlert
+            v-else-if="venueDetailsError"
+            color="red"
+            variant="soft"
+            :description="venueDetailsError"
+          />
+          <template v-else>
+            <div v-if="selectedVenuePhotoUrl" class="overflow-hidden rounded-lg bg-gray-100">
+              <img
+                :src="selectedVenuePhotoUrl"
+                :alt="selectedVenueDetails.venuename || selectedVenue.name"
+                class="max-h-64 w-full object-cover"
+              >
+            </div>
+            <p v-if="selectedVenueDetails?.description" class="text-sm leading-6 text-gray-700 dark:text-gray-200">
+              {{ selectedVenueDetails.description }}
+            </p>
+            <div class="grid gap-3 text-sm sm:grid-cols-2">
+              <div
+                v-for="detail in selectedVenueDetailRows"
+                :key="detail.label"
+                class="rounded-md border border-gray-200 p-3 dark:border-gray-800"
+              >
+                <dt class="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  {{ detail.label }}
+                </dt>
+                <dd class="mt-1 break-words text-gray-900 dark:text-white">
+                  <a
+                    v-if="detail.href"
+                    :href="detail.href"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-amber-700 hover:text-amber-800"
+                  >
+                    {{ detail.value }}
+                  </a>
+                  <span v-else>{{ detail.value }}</span>
+                </dd>
+              </div>
+            </div>
+            <div v-if="selectedVenueFeatureLines.length" class="text-sm text-gray-700 dark:text-gray-200">
+              <h4 class="mb-2 font-semibold text-gray-900 dark:text-white">Features</h4>
+              <ul class="space-y-1">
+                <li v-for="feature in selectedVenueFeatureLines" :key="feature">
+                  {{ feature }}
+                </li>
+              </ul>
+            </div>
+          </template>
           <div class="flex flex-wrap gap-2">
             <UButton
               v-if="selectedVenue.id"
               color="amber"
               variant="solid"
-              :to="`/venues/${selectedVenue.id}`"
+              :to="selectedVenueUrl"
               label="View venue"
             />
             <UButton
@@ -82,6 +157,7 @@
 import { ref, reactive, onMounted, computed } from 'vue'
 import { useVenueStore } from '@/store/venue.js'
 import { useEventStore } from '@/store/event.js'
+import { resolveVenueDisplayPhotoUrl } from '@/utils/format-venue'
 
 useSiteSeo({
   title: 'Map of UK pubs and venues',
@@ -92,6 +168,7 @@ useSiteSeo({
 const venueStore = useVenueStore()
 const eventStore = useEventStore()
 const mapboxToken = useMapboxToken()
+const config = useRuntimeConfig()
 
 const selectedCity = ref('')
 const cityNames = computed(() => eventStore.cities.map((city) => city.name))
@@ -134,8 +211,37 @@ type MapVenuePoint = {
 }
 
 type SelectedMapVenue = MapVenuePoint
+type VenueDetails = Record<string, unknown> & {
+  id?: number
+  fsa_id?: number
+  venuename?: string
+  slug?: string
+  venuetype?: string
+  address?: string
+  address2?: string
+  town?: string
+  county?: string
+  postcode?: string
+  telephone?: string
+  website?: string
+  local_authority?: string
+  features?: string
+  description?: string
+  photo?: string
+  postalsearch?: string
+  easting?: string
+  northing?: string
+  is_live?: string
+  created_at?: string
+  updated_at?: string
+  latitude?: string
+  longitude?: string
+}
 
 onMounted(async () => {
+  desktopMediaQuery = window.matchMedia('(min-width: 768px)')
+  updateDesktopViewport()
+  desktopMediaQuery.addEventListener('change', updateDesktopViewport)
   void eventStore.fetchCities()
   void loadFilterData()
   await createMap()
@@ -152,21 +258,93 @@ const showVenueEvents = () => {
 
 const isVenueModalOpen = ref(false)
 const selectedVenue = ref<SelectedMapVenue | null>(null)
+const selectedVenueDetails = ref<VenueDetails | null>(null)
+const isVenueDetailsLoading = ref(false)
+const venueDetailsError = ref('')
+const isDesktopViewport = ref(true)
 const selectedVenueAddressLines = computed(() => {
-  if (!selectedVenue.value) return []
-  return compactAddressLines(selectedVenue.value)
+  const venue = selectedVenueDetails.value || selectedVenue.value
+  if (!venue) return []
+  return compactAddressLines({
+    address: readVenueString(venue, 'address'),
+    address2: readVenueString(venue, 'address2'),
+    town: readVenueString(venue, 'town'),
+    county: readVenueString(venue, 'county'),
+    postcode: readVenueString(venue, 'postcode'),
+  })
 })
+const selectedVenueUrl = computed(() => {
+  if (!selectedVenue.value?.id) return ''
+  const slug = readVenueString(selectedVenueDetails.value, 'slug')
+  return slug ? `/venues/${selectedVenue.value.id}/${slug}` : `/venues/${selectedVenue.value.id}`
+})
+const selectedVenueFeatureLines = computed(() => {
+  const features = readVenueString(selectedVenueDetails.value, 'features')
+  if (!features) return []
+  return features
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+})
+const selectedVenuePhotoUrl = computed(() => {
+  const photo = readVenueString(selectedVenueDetails.value, 'photo')
+  if (!photo) return ''
+  return resolveVenueDisplayPhotoUrl(photo, {
+    venueImgFolder: config.public.venueImgFolder as string | undefined,
+    supabaseUrl: config.public.supabase?.url as string | undefined,
+  })
+})
+const selectedVenueDetailRows = computed(() => {
+  const venue = selectedVenueDetails.value
+  if (!venue) return []
+
+  const website = readVenueString(venue, 'website')
+  const telephone = readVenueString(venue, 'telephone')
+  const rows: Array<{ label: string; value: string; href?: string }> = [
+    { label: 'Venue name', value: readVenueString(venue, 'venuename') },
+    { label: 'Venue type', value: readVenueString(venue, 'venuetype') },
+    { label: 'Address', value: selectedVenueAddressLines.value.join(', ') },
+    { label: 'Telephone', value: telephone, href: telephoneHref(telephone) },
+    { label: 'Website', value: website, href: websiteHref(website) },
+    { label: 'Town', value: readVenueString(venue, 'town') },
+    { label: 'County', value: readVenueString(venue, 'county') },
+    { label: 'Postcode', value: readVenueString(venue, 'postcode') },
+    { label: 'Postcode search', value: readVenueString(venue, 'postalsearch') },
+    { label: 'Local authority', value: readVenueString(venue, 'local_authority') },
+    { label: 'Latitude', value: readVenueString(venue, 'latitude') },
+    { label: 'Longitude', value: readVenueString(venue, 'longitude') },
+    { label: 'Easting', value: readVenueString(venue, 'easting') },
+    { label: 'Northing', value: readVenueString(venue, 'northing') },
+    { label: 'Photo', value: readVenueString(venue, 'photo'), href: photoHref(readVenueString(venue, 'photo')) },
+    { label: 'Live status', value: readVenueString(venue, 'is_live') },
+    { label: 'Venue ID', value: readVenueString(venue, 'id') },
+    { label: 'FSA ID', value: readVenueString(venue, 'fsa_id') },
+    { label: 'Slug', value: readVenueString(venue, 'slug') },
+    { label: 'Created', value: readVenueString(venue, 'created_at') },
+    { label: 'Updated', value: readVenueString(venue, 'updated_at') },
+  ]
+
+  return rows.filter((row) => row.value)
+})
+
+let desktopMediaQuery: MediaQueryList | null = null
 
 function closeVenueModal() {
   isVenueModalOpen.value = false
-  selectedVenue.value = null
 }
 
 function openSelectedVenueEvents() {
   if (!selectedVenue.value) return
   venueStore.venue = { id: selectedVenue.value.id }
-  isVenueModalOpen.value = false
+  if (!isDesktopViewport.value) {
+    isVenueModalOpen.value = false
+  }
   isOpenLeft.slideover = true
+}
+
+function reopenVenueDetails() {
+  isOpenLeft.slideover = false
+  isVenueModalOpen.value = true
 }
 
 const searchCity = (city: string | number | boolean) => {
@@ -455,7 +633,10 @@ function bindClusterHandlers() {
     const venue = mapFeatureToVenue(e.features[0]?.properties)
     if (!venue) return
     selectedVenue.value = venue
+    selectedVenueDetails.value = null
+    venueDetailsError.value = ''
     isVenueModalOpen.value = true
+    void loadSelectedVenueDetails(venue.id)
   })
 
   const setPointer = () => {
@@ -479,9 +660,16 @@ function escapeHtml(text: unknown) {
     .replace(/"/g, '&quot;')
 }
 
-function compactAddressLines(venue: Pick<MapVenuePoint, 'address' | 'town' | 'county' | 'postcode'>) {
+function compactAddressLines(venue: {
+  address?: string
+  address2?: string
+  town?: string
+  county?: string
+  postcode?: string
+}) {
   return [
     venue.address,
+    venue.address2,
     [venue.town, venue.county].filter(Boolean).join(', '),
     venue.postcode,
   ].filter((line): line is string => Boolean(String(line || '').trim()))
@@ -490,6 +678,7 @@ function compactAddressLines(venue: Pick<MapVenuePoint, 'address' | 'town' | 'co
 function formatAddress(properties: Record<string, unknown>) {
   return compactAddressLines({
     address: String(properties.address || ''),
+    address2: '',
     town: String(properties.town || ''),
     county: String(properties.county || ''),
     postcode: String(properties.postcode || ''),
@@ -516,8 +705,46 @@ function mapFeatureToVenue(properties?: Record<string, unknown>): SelectedMapVen
   }
 }
 
+async function loadSelectedVenueDetails(id: number) {
+  if (!id) return
+  isVenueDetailsLoading.value = true
+  venueDetailsError.value = ''
+  try {
+    selectedVenueDetails.value = await venueStore.fetchVenueDetails(id)
+  } catch (err) {
+    console.error('Failed to load venue details:', err)
+    venueDetailsError.value = 'Unable to load full venue details. Please try again.'
+  } finally {
+    isVenueDetailsLoading.value = false
+  }
+}
+
+function readVenueString(venue: object | null | undefined, key: string) {
+  const value = (venue as Record<string, unknown> | null | undefined)?.[key]
+  return value == null ? '' : String(value).trim()
+}
+
+function telephoneHref(value: string) {
+  const cleaned = value.replace(/[^\d+]/g, '')
+  return cleaned ? `tel:${cleaned}` : ''
+}
+
+function websiteHref(value: string) {
+  if (!value) return ''
+  return /^https?:\/\//i.test(value) ? value : `https://${value}`
+}
+
+function photoHref(value: string) {
+  return /^https?:\/\//i.test(value) ? value : ''
+}
+
+function updateDesktopViewport() {
+  isDesktopViewport.value = desktopMediaQuery?.matches ?? true
+}
+
 onBeforeUnmount(() => {
   if (popupTimeout) clearTimeout(popupTimeout)
+  desktopMediaQuery?.removeEventListener('change', updateDesktopViewport)
   popup?.remove()
   map.value?.remove()
   map.value = null


### PR DESCRIPTION
## Summary
- fetch full venue details when a map pin is clicked
- show address in the hover popup and show all available venue details in the modal
- keep the details modal open when opening events on desktop
- on mobile, close the details modal, open events in the left panel, and show a back-to-details link plus close button

## Verification
- npm run build