### PR TITLE
Fix map 502 and homepage image fallbacks

### DIFF
--- a/components/home/HomeRankedList.vue
+++ b/components/home/HomeRankedList.vue
@@ -19,7 +19,7 @@
           >
             <img
               v-if="hasUsableImage(item, index)"
-              :src="item.imageUrl || ''"
+              :src="imageSrc(item, index)"
               :alt="imageAlt(item)"
               class="absolute inset-0 h-full w-full object-cover"
               loading="lazy"
@@ -80,10 +80,12 @@ const props = withDefaults(
     items: HomeRankedItem[]
     countLabel?: { singular: string; plural: string }
     photoCards?: boolean
+    fallbackImageUrl?: string
   }>(),
   {
     countLabel: () => ({ singular: 'pub', plural: 'pubs' }),
     photoCards: false,
+    fallbackImageUrl: '/assets/images/awaiting.jpg',
   },
 )
 
@@ -98,12 +100,20 @@ function imageKey(item: HomeRankedItem, index: number) {
 }
 
 function hasUsableImage(item: HomeRankedItem, index: number) {
-  return Boolean(item.imageUrl) && !failedImageKeys.value.has(imageKey(item, index))
+  const src = imageSrc(item, index)
+  return Boolean(src) && !failedImageKeys.value.has(src)
+}
+
+function imageSrc(item: HomeRankedItem, index: number) {
+  if (item.imageUrl && !failedImageKeys.value.has(imageKey(item, index))) {
+    return item.imageUrl
+  }
+  return props.fallbackImageUrl
 }
 
 function markImageFailed(item: HomeRankedItem, index: number) {
   const nextFailedImageKeys = new Set(failedImageKeys.value)
-  nextFailedImageKeys.add(imageKey(item, index))
+  nextFailedImageKeys.add(imageSrc(item, index))
   failedImageKeys.value = nextFailedImageKeys
 }
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -30,6 +30,7 @@
           description="Counties ranked by venue listings across England, Scotland, and Wales."
           :items="stats.topCounties"
           photo-cards
+          fallback-image-url="/assets/images/headers/brighton-and-hove.jpg"
         />
       </div>
 
@@ -46,6 +47,7 @@
           :description="`Live venue listings within ${stats.stadiumRadiusMiles} mile of each stadium (straight-line distance).`"
           :items="stadiumListItems"
           photo-cards
+          fallback-image-url="/assets/images/filip-andrejevic-QmX5lw8StoQ-unsplash.jpg"
         />
       </section>
 

--- a/pages/map/index.vue
+++ b/pages/map/index.vue
@@ -190,6 +190,7 @@ const mapVenues = ref<MapVenuePoint[]>([])
 let mapboxgl: typeof import('mapbox-gl').default | null = null
 let popup: InstanceType<typeof import('mapbox-gl').default.Popup> | null = null
 let popupTimeout: ReturnType<typeof setTimeout> | null = null
+let activePopupVenueId: number | null = null
 const hiddenLegacyLayerIds = ref(new Set<string>())
 
 const SOURCE_ID = 'venue-clusters'
@@ -201,7 +202,6 @@ type MapVenuePoint = {
   id: number
   fsaId: number
   name: string
-  address: string
   lat: number
   lng: number
 }
@@ -324,6 +324,7 @@ const selectedVenueDetailRows = computed(() => {
 })
 
 let desktopMediaQuery: MediaQueryList | null = null
+const venueDetailsCache = new Map<number, VenueDetails>()
 
 function closeVenueModal() {
   isVenueModalOpen.value = false
@@ -476,7 +477,6 @@ function buildVenueGeoJson(venues: MapVenuePoint[]) {
             id: venue.id,
             fsa_id: venue.fsaId,
             venuename: venue.name,
-            address: venue.address,
             lat,
             lng,
           },
@@ -598,24 +598,25 @@ function bindClusterHandlers() {
 
     const coordinates = feature.geometry.coordinates.slice()
     const { venuename } = feature.properties
-    const address = formatAddress(feature.properties)
+    const venueId = Number(feature.properties?.id || 0)
+    activePopupVenueId = venueId || null
 
     popup?.remove()
     popup = new mapboxgl.Popup({ closeButton: false })
       .setLngLat(coordinates)
-      .setHTML(
-        `<div class="p-2">
-          <h1 class="text-lg font-semibold">${escapeHtml(venuename)}</h1>
-          ${address ? `<p class="mt-1 text-sm leading-snug">${escapeHtml(address)}</p>` : ''}
-        </div>`,
-      )
+      .setHTML(renderVenuePopupHtml(venuename, popupAddressForVenue(venueId)))
       .addTo(map.value)
+
+    if (venueId && !venueDetailsCache.has(venueId)) {
+      void fetchVenueDetailsForPopup(venueId, venuename, coordinates)
+    }
   })
 
   map.value.on('mouseleave', LAYER_UNCLUSTERED, () => {
     popupTimeout = setTimeout(() => {
       popup?.remove()
       popup = null
+      activePopupVenueId = null
     }, 500)
   })
 
@@ -668,7 +669,13 @@ function compactAddressLines(venue: {
 }
 
 function formatAddress(properties: Record<string, unknown>) {
-  return String(properties.address || '').trim()
+  return compactAddressLines({
+    address: String(properties.address || ''),
+    address2: String(properties.address2 || ''),
+    town: String(properties.town || ''),
+    county: String(properties.county || ''),
+    postcode: String(properties.postcode || ''),
+  }).join(', ')
 }
 
 function mapFeatureToVenue(properties?: Record<string, unknown>): SelectedMapVenue | null {
@@ -681,7 +688,6 @@ function mapFeatureToVenue(properties?: Record<string, unknown>): SelectedMapVen
     id: Number(properties.id || 0),
     fsaId: Number(properties.fsa_id || 0),
     name: String(properties.venuename || ''),
-    address: String(properties.address || ''),
     lat,
     lng,
   }
@@ -692,12 +698,43 @@ async function loadSelectedVenueDetails(id: number) {
   isVenueDetailsLoading.value = true
   venueDetailsError.value = ''
   try {
-    selectedVenueDetails.value = await venueStore.fetchVenueDetails(id)
+    selectedVenueDetails.value = await fetchVenueDetailsCached(id)
   } catch (err) {
     console.error('Failed to load venue details:', err)
     venueDetailsError.value = 'Unable to load full venue details. Please try again.'
   } finally {
     isVenueDetailsLoading.value = false
+  }
+}
+
+async function fetchVenueDetailsCached(id: number) {
+  const cached = venueDetailsCache.get(id)
+  if (cached) return cached
+
+  const details = await venueStore.fetchVenueDetails(id)
+  venueDetailsCache.set(id, details)
+  return details
+}
+
+function popupAddressForVenue(id: number) {
+  const details = venueDetailsCache.get(id)
+  return details ? formatAddress(details) : ''
+}
+
+function renderVenuePopupHtml(venuename: unknown, address = '') {
+  return `<div class="p-2">
+    <h1 class="text-lg font-semibold">${escapeHtml(venuename)}</h1>
+    ${address ? `<p class="mt-1 text-sm leading-snug">${escapeHtml(address)}</p>` : '<p class="mt-1 text-sm leading-snug text-gray-500">Loading address...</p>'}
+  </div>`
+}
+
+async function fetchVenueDetailsForPopup(id: number, venuename: unknown, coordinates: [number, number]) {
+  try {
+    const details = await fetchVenueDetailsCached(id)
+    if (!popup || !map.value || activePopupVenueId !== id) return
+    popup.setLngLat(coordinates).setHTML(renderVenuePopupHtml(venuename, formatAddress(details)))
+  } catch (err) {
+    console.error('Failed to load venue popup details:', err)
   }
 }
 

--- a/server/api/venues/map.get.ts
+++ b/server/api/venues/map.get.ts
@@ -3,10 +3,6 @@ type MapVenueRow = {
   id: number
   fsa_id: number
   venuename: string
-  address: string
-  town: string
-  county: string
-  postcode: string
   latitude: string | null
   longitude: string | null
 }
@@ -15,7 +11,6 @@ type MapVenuePoint = {
   id: number
   fsaId: number
   name: string
-  address: string
   lat: number
   lng: number
 }
@@ -40,7 +35,6 @@ function mapRowsToPoints(rows: MapVenueRow[]): MapVenuePoint[] {
       id: venue.id,
       fsaId: venue.fsa_id,
       name: venue.venuename,
-      address: formatAddress(venue),
       lat,
       lng,
     })
@@ -48,17 +42,7 @@ function mapRowsToPoints(rows: MapVenueRow[]): MapVenuePoint[] {
   return points
 }
 
-function formatAddress(venue: Pick<MapVenueRow, 'address' | 'town' | 'county' | 'postcode'>) {
-  return [
-    venue.address,
-    [venue.town, venue.county].filter(Boolean).join(', '),
-    venue.postcode,
-  ]
-    .filter((part) => Boolean(String(part || '').trim()))
-    .join(', ')
-}
-
-/** Lightweight venue points for clustered hub maps (cached, coord-filtered in SQL). */
+/** Lightweight venue points for clustered hub maps. Keep this response below Netlify payload limits. */
 export default defineEventHandler(async (event) => {
   setResponseHeader(event, 'Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=86400')
 
@@ -77,10 +61,6 @@ export default defineEventHandler(async (event) => {
         id: true,
         fsa_id: true,
         venuename: true,
-        address: true,
-        town: true,
-        county: true,
-        postcode: true,
         latitude: true,
         longitude: true,
       },


### PR DESCRIPTION
## Summary
- keep /api/venues/map below Netlify response-size limits by removing address fields from the bulk cluster payload
- fetch/cache a single venue detail record for the hover popup address and clicked modal
- add local fallback images for homepage county and stadium photo cards when stored remote images fail

## Verification
- npm run build
- confirmed previous preview 502 body was Function.ResponseSizeTooLarge