### PR TITLE
Update World Cup banner: Change to England vs Argentina semi-final

### DIFF
--- a/components/home/HomeWorldCupBanner.vue
+++ b/components/home/HomeWorldCupBanner.vue
@@ -2,30 +2,30 @@
   <section
     v-if="showBanner"
     class="world-cup-banner border-b border-amber-700/30 bg-gradient-to-r from-green-900 via-gray-900 to-red-900"
-    aria-label="Norway vs England World Cup match"
+    aria-label="England vs Argentina World Cup match"
   >
     <div class="container mx-auto px-4 py-8 md:py-10">
       <div class="text-center">
         <p class="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-amber-300">
-          FIFA World Cup 2026 · Quarter-final
+          FIFA World Cup 2026 · Semi-final
         </p>
 
         <h2 class="sr-only">
-          Norway vs England World Cup 2026 — pubs and sports bars showing the match across the UK
+          England vs Argentina World Cup 2026 — pubs and sports bars showing the match across the UK
         </h2>
 
-        <div class="mb-4 flex items-center justify-center gap-4 md:gap-8" role="group" aria-label="Norway vs England">
+        <div class="mb-4 flex items-center justify-center gap-4 md:gap-8" role="group" aria-label="England vs Argentina">
           <div class="flex flex-col items-center gap-2">
             <img
-              src="https://flagcdn.com/w80/no.png"
-              srcset="https://flagcdn.com/w160/no.png 2x"
+              src="https://flagcdn.com/w80/gb-eng.png"
+              srcset="https://flagcdn.com/w160/gb-eng.png 2x"
               width="64"
               height="43"
-              alt="Norway flag"
+              alt="England flag"
               class="h-12 w-auto rounded shadow-md md:h-16"
               loading="eager"
             />
-            <span class="text-lg font-bold text-white md:text-xl">Norway</span>
+            <span class="text-lg font-bold text-white md:text-xl">England</span>
           </div>
 
           <div class="flex flex-col items-center">
@@ -40,22 +40,22 @@
 
           <div class="flex flex-col items-center gap-2">
             <img
-              src="https://flagcdn.com/w80/gb-eng.png"
-              srcset="https://flagcdn.com/w160/gb-eng.png 2x"
+              src="https://flagcdn.com/w80/ar.png"
+              srcset="https://flagcdn.com/w160/ar.png 2x"
               width="64"
               height="43"
-              alt="England flag"
+              alt="Argentina flag"
               class="h-12 w-auto rounded shadow-md md:h-16"
               loading="eager"
             />
-            <span class="text-lg font-bold text-white md:text-xl">England</span>
+            <span class="text-lg font-bold text-white md:text-xl">Argentina</span>
           </div>
         </div>
 
         <p class="mx-auto mb-4 max-w-2xl text-sm text-white/80 md:text-base">
           Live on <strong class="text-white">BBC One</strong> from Hard Rock Stadium, Miami.
           Find a <strong class="text-white">sports pub</strong> or <strong class="text-white">World Cup venue</strong> near you —
-          watch this 10pm quarter-final at your local sports bar.
+          watch this 10pm semi-final at your local sports bar.
         </p>
 
         <p class="mx-auto mb-6 max-w-3xl text-xs leading-relaxed text-white/60 md:text-sm">
@@ -95,7 +95,7 @@
         </h3>
         <p class="border-t border-white/10 px-4 pt-4 text-sm leading-relaxed text-white/70">
           These are among the best <strong class="text-white/90">UK sports pubs and World Cup venues</strong> likely
-          screening Norway vs England — popular <strong class="text-white/90">football pubs</strong> with multiple
+          screening England vs Argentina — popular <strong class="text-white/90">football pubs</strong> with multiple
           screens, late opening hours and strong match-day atmosphere. Search UK Pubs for
           <strong class="text-white/90">sports bars near you</strong>, or browse by city for
           <strong class="text-white/90">World Cup 2026 pub listings</strong> in your area.
@@ -113,7 +113,7 @@
         </div>
         <p class="border-t border-white/10 px-4 py-3 text-xs leading-relaxed text-white/50">
           Confirm with venues before travelling — many sports pubs and bars will be screening this
-          <strong class="text-white/65">England World Cup quarter-final</strong>.
+          <strong class="text-white/65">England World Cup semi-final</strong>.
           Listings sourced from FANZO and major UK sports bar chains. Also search UK Pubs for
           <strong class="text-white/65">sports TV pubs</strong>,
           <strong class="text-white/65">football bars</strong>,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes

Updated the World Cup banner on the homepage to reflect the semi-final match between England and Argentina.

### What was changed:
- Changed match from "Norway vs England" to "England vs Argentina"
- Updated match stage from "Quarter-final" to "Semi-final"
- Swapped Norway flag (🇳🇴) for Argentina flag (🇦🇷)
- Updated all aria-labels and accessibility text
- Modified descriptive text throughout the banner to reference the semi-final

### Technical details:
- Updated flag URLs from `no.png` to `ar.png` and `gb-eng.png` positioning
- England now appears first (left side), Argentina second (right side)
- All references to "quarter-final" changed to "semi-final"
- Match date/time remains the same: Sat 11 Jul · 10:00pm BST
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f55a6-a847-7e24-be67-a7d952fb71df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f55a6-a847-7e24-be67-a7d952fb71df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

