### PR TITLE
Pub crawl builder on the maps page

### DIFF
--- a/components/map/PubCrawlBuilder.vue
+++ b/components/map/PubCrawlBuilder.vue
@@ -1,0 +1,625 @@
+<template>
+  <div class="flex h-full flex-col">
+    <div class="flex items-start justify-between gap-3 border-b border-gray-200 px-4 py-3 dark:border-gray-800">
+      <div>
+        <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Pub crawl builder</h2>
+        <p class="mt-0.5 text-sm text-gray-500 dark:text-gray-400">
+          Pick pubs on the map, reorder the route, and track your progress.
+        </p>
+      </div>
+      <UButton
+        color="gray"
+        variant="ghost"
+        icon="i-heroicons-x-mark-20-solid"
+        aria-label="Close pub crawl builder"
+        @click="$emit('close')"
+      />
+    </div>
+
+    <div class="flex-1 space-y-4 overflow-y-auto p-4">
+      <UAlert
+        v-if="errorMessage"
+        color="red"
+        variant="soft"
+        :description="errorMessage"
+        :close-button="{ icon: 'i-heroicons-x-mark-20-solid', color: 'red', variant: 'link' }"
+        @close="errorMessage = ''"
+      />
+
+      <!-- Saved crawls -->
+      <section class="space-y-2">
+        <div class="flex items-center justify-between gap-2">
+          <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">Your crawls</h3>
+          <UButton
+            size="xs"
+            color="gray"
+            variant="ghost"
+            icon="i-heroicons-arrow-path-20-solid"
+            :loading="loadingList"
+            aria-label="Refresh crawls"
+            @click="loadCrawls"
+          />
+        </div>
+
+        <div v-if="loadingList && !crawls.length" class="text-sm text-gray-500">Loading…</div>
+        <ul v-else-if="crawls.length" class="space-y-1">
+          <li
+            v-for="crawl in crawls"
+            :key="crawl.id"
+            class="flex items-center gap-2 rounded-md border px-2 py-1.5 text-sm"
+            :class="crawl.id === activeCrawl?.id
+              ? 'border-amber-400 bg-amber-50 dark:border-amber-700 dark:bg-amber-950/40'
+              : 'border-gray-200 dark:border-gray-800'"
+          >
+            <button
+              type="button"
+              class="min-w-0 flex-1 text-left"
+              @click="loadCrawl(crawl.id)"
+            >
+              <span class="block truncate font-medium text-gray-900 dark:text-white">{{ crawl.name }}</span>
+              <span class="text-xs text-gray-500">
+                {{ crawl.stopCount }} stop{{ crawl.stopCount === 1 ? '' : 's' }}
+                <template v-if="crawl.stopCount">
+                  · at #{{ Math.min(crawl.currentStopIndex + 1, crawl.stopCount) }}
+                </template>
+              </span>
+            </button>
+            <UButton
+              size="xs"
+              color="red"
+              variant="ghost"
+              icon="i-heroicons-trash-20-solid"
+              aria-label="Delete crawl"
+              :loading="deletingId === crawl.id"
+              @click="deleteCrawl(crawl.id)"
+            />
+          </li>
+        </ul>
+        <p v-else class="text-sm text-gray-500">No saved crawls yet. Create one below.</p>
+      </section>
+
+      <!-- Create / rename -->
+      <section class="space-y-2 rounded-md border border-gray-200 p-3 dark:border-gray-800">
+        <label class="block text-sm font-medium text-gray-900 dark:text-white">
+          {{ activeCrawl ? 'Crawl name' : 'New crawl name' }}
+        </label>
+        <div class="flex gap-2">
+          <UInput
+            v-model="draftName"
+            class="flex-1"
+            placeholder="e.g. Friday night in Liverpool"
+            maxlength="120"
+            @keydown.enter.prevent="activeCrawl ? saveMeta() : createCrawl()"
+          />
+          <UButton
+            v-if="!activeCrawl"
+            color="amber"
+            :loading="saving"
+            :disabled="!draftName.trim()"
+            label="Create"
+            @click="createCrawl"
+          />
+          <UButton
+            v-else
+            color="amber"
+            variant="soft"
+            :loading="saving"
+            :disabled="!draftName.trim() || draftName.trim() === activeCrawl.name"
+            label="Rename"
+            @click="saveMeta"
+          />
+        </div>
+        <UButton
+          v-if="activeCrawl"
+          size="xs"
+          color="gray"
+          variant="link"
+          label="Start a new crawl"
+          @click="startFresh"
+        />
+      </section>
+
+      <template v-if="activeCrawl">
+        <!-- Manual add -->
+        <section class="space-y-2">
+          <h3 class="text-sm font-semibold text-gray-900 dark:text-white">Add a pub</h3>
+          <p class="text-xs text-gray-500">
+            Click a pub on the map and use “Add to crawl”, or type a name here.
+          </p>
+          <div class="flex gap-2">
+            <UInput
+              v-model="manualName"
+              class="flex-1"
+              placeholder="Type a pub name…"
+              maxlength="200"
+              @keydown.enter.prevent="addManualStop"
+            />
+            <UButton
+              color="gray"
+              variant="soft"
+              :disabled="!manualName.trim() || addingStop"
+              :loading="addingStop"
+              label="Add"
+              @click="addManualStop"
+            />
+          </div>
+        </section>
+
+        <!-- Ordered stops -->
+        <section class="space-y-2">
+          <div class="flex items-center justify-between gap-2">
+            <h3 class="text-sm font-semibold text-gray-900 dark:text-white">
+              Route
+              <span v-if="stops.length" class="font-normal text-gray-500">
+                ({{ stops.length }} stop{{ stops.length === 1 ? '' : 's' }})
+              </span>
+            </h3>
+            <span v-if="totalWalkLabel" class="text-xs text-gray-500">{{ totalWalkLabel }}</span>
+          </div>
+
+          <p v-if="!stops.length" class="text-sm text-gray-500">
+            No pubs yet. Select venues on the map or add one by name.
+          </p>
+
+          <ol v-else class="m-0 list-none space-y-0 p-0">
+            <template v-for="(stop, index) in stops" :key="stop.id || `draft-${index}`">
+              <li
+                class="rounded-md border bg-white dark:bg-gray-900"
+                :class="{
+                  'border-amber-400 ring-1 ring-amber-400': dragIndex === index,
+                  'border-amber-300': dropIndex === index && dragIndex !== index,
+                  'border-emerald-400 bg-emerald-50/60 dark:border-emerald-700 dark:bg-emerald-950/30': index === currentStopIndex,
+                  'border-gray-200 dark:border-gray-800': dragIndex !== index && dropIndex !== index && index !== currentStopIndex,
+                }"
+                draggable="true"
+                @dragstart="onDragStart(index, $event)"
+                @dragend="onDragEnd"
+                @dragover.prevent="onDragOver(index)"
+                @dragleave="onDragLeave(index)"
+                @drop.prevent="onDrop(index)"
+              >
+                <div class="flex items-start gap-2 px-2 py-2">
+                  <button
+                    type="button"
+                    class="mt-0.5 cursor-grab touch-none text-gray-400 active:cursor-grabbing"
+                    aria-label="Drag to reorder"
+                    @click.stop
+                  >
+                    <UIcon name="i-heroicons-bars-3-20-solid" class="h-5 w-5" />
+                  </button>
+                  <div class="min-w-0 flex-1">
+                    <div class="flex flex-wrap items-center gap-2">
+                      <span
+                        class="inline-flex h-6 min-w-[1.5rem] items-center justify-center rounded bg-amber-100 px-1.5 text-xs font-semibold text-amber-900 dark:bg-amber-900 dark:text-amber-100"
+                      >
+                        {{ index + 1 }}
+                      </span>
+                      <span
+                        v-if="index === 0"
+                        class="rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-gray-600 dark:bg-gray-800 dark:text-gray-300"
+                      >
+                        Start
+                      </span>
+                      <span
+                        v-else-if="index === stops.length - 1"
+                        class="rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-gray-600 dark:bg-gray-800 dark:text-gray-300"
+                      >
+                        Finish
+                      </span>
+                      <span
+                        v-if="index === currentStopIndex"
+                        class="rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-emerald-800 dark:bg-emerald-900 dark:text-emerald-100"
+                      >
+                        You are here
+                      </span>
+                    </div>
+                    <p class="mt-1 truncate font-medium text-gray-900 dark:text-white">
+                      {{ stop.venueName }}
+                    </p>
+                    <p v-if="!stop.venueId" class="text-xs text-gray-500">Added manually</p>
+                  </div>
+                  <div class="flex shrink-0 flex-col items-end gap-1">
+                    <UButton
+                      size="xs"
+                      color="gray"
+                      variant="ghost"
+                      label="Here"
+                      :disabled="index === currentStopIndex"
+                      @click="setProgress(index)"
+                    />
+                    <UButton
+                      size="xs"
+                      color="red"
+                      variant="ghost"
+                      icon="i-heroicons-x-mark-20-solid"
+                      aria-label="Remove stop"
+                      @click="removeStop(index)"
+                    />
+                  </div>
+                </div>
+              </li>
+
+              <li
+                v-if="index < stops.length - 1"
+                class="flex items-center gap-2 py-1.5 pl-8 text-xs text-gray-500"
+              >
+                <UIcon name="i-heroicons-arrow-long-down-20-solid" class="h-4 w-4 shrink-0 text-amber-600" />
+                <span>{{ legLabel(index) }}</span>
+              </li>
+            </template>
+          </ol>
+        </section>
+
+        <!-- Progress + save -->
+        <section class="space-y-3 border-t border-gray-200 pt-3 dark:border-gray-800">
+          <div v-if="stops.length" class="space-y-1">
+            <div class="flex justify-between text-xs text-gray-500">
+              <span>Progress</span>
+              <span>{{ currentStopIndex + 1 }} / {{ stops.length }}</span>
+            </div>
+            <div class="h-2 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
+              <div
+                class="h-full rounded-full bg-emerald-500 transition-all"
+                :style="{ width: `${progressPercent}%` }"
+              />
+            </div>
+            <div class="flex gap-2 pt-1">
+              <UButton
+                size="xs"
+                color="gray"
+                variant="soft"
+                label="Previous"
+                :disabled="currentStopIndex <= 0 || saving"
+                @click="setProgress(currentStopIndex - 1)"
+              />
+              <UButton
+                size="xs"
+                color="emerald"
+                variant="soft"
+                label="Next pub"
+                :disabled="currentStopIndex >= stops.length - 1 || saving"
+                @click="setProgress(currentStopIndex + 1)"
+              />
+            </div>
+          </div>
+
+          <UButton
+            block
+            color="amber"
+            :loading="saving"
+            :disabled="!dirty"
+            label="Save crawl"
+            @click="saveCrawl"
+          />
+          <p v-if="lastSavedAt" class="text-center text-xs text-gray-500">
+            Saved {{ lastSavedAt }}
+          </p>
+        </section>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { buildCrawlLegs, formatWalkingDistance } from '@/utils/crawl-distance'
+
+export type CrawlStop = {
+  id?: string
+  venueId: number | null
+  venueName: string
+  latitude: number | null
+  longitude: number | null
+  notes?: string | null
+  sortOrder?: number
+}
+
+export type CrawlSummary = {
+  id: string
+  name: string
+  currentStopIndex: number
+  stopCount: number
+  updatedAt: string
+  stops?: CrawlStop[]
+}
+
+const emit = defineEmits<{
+  close: []
+  'crawl-updated': [crawl: CrawlSummary | null]
+}>()
+
+const { isLoggedIn, initializeAuth } = useAuth()
+
+const crawls = ref<CrawlSummary[]>([])
+const activeCrawl = ref<CrawlSummary | null>(null)
+const stops = ref<CrawlStop[]>([])
+const currentStopIndex = ref(0)
+const draftName = ref('')
+const manualName = ref('')
+const loadingList = ref(false)
+const saving = ref(false)
+const addingStop = ref(false)
+const deletingId = ref<string | null>(null)
+const errorMessage = ref('')
+const dirty = ref(false)
+const lastSavedAt = ref('')
+const dragIndex = ref<number | null>(null)
+const dropIndex = ref<number | null>(null)
+
+const legs = computed(() => buildCrawlLegs(stops.value))
+
+const totalWalkLabel = computed(() => {
+  const miles = legs.value.reduce((sum, leg) => sum + (leg.miles ?? 0), 0)
+  if (!miles) return ''
+  return `Total ~${formatWalkingDistance(miles).replace(/^~/, '')}`
+})
+
+const progressPercent = computed(() => {
+  if (!stops.value.length) return 0
+  return Math.round(((currentStopIndex.value + 1) / stops.value.length) * 100)
+})
+
+function legLabel(fromIndex: number) {
+  return legs.value[fromIndex]?.label || 'Distance unknown'
+}
+
+function markDirty() {
+  dirty.value = true
+}
+
+function startFresh() {
+  activeCrawl.value = null
+  stops.value = []
+  currentStopIndex.value = 0
+  draftName.value = ''
+  dirty.value = false
+  lastSavedAt.value = ''
+  emit('crawl-updated', null)
+}
+
+async function loadCrawls() {
+  if (!isLoggedIn.value) return
+  loadingList.value = true
+  errorMessage.value = ''
+  try {
+    crawls.value = await useAuthFetch<CrawlSummary[]>('/api/crawls')
+  } catch (err: any) {
+    errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not load crawls'
+  } finally {
+    loadingList.value = false
+  }
+}
+
+async function createCrawl() {
+  const name = draftName.value.trim()
+  if (!name) return
+  saving.value = true
+  errorMessage.value = ''
+  try {
+    const crawl = await useAuthFetch<CrawlSummary>('/api/crawls', {
+      method: 'POST',
+      body: { name },
+    })
+    activeCrawl.value = crawl
+    stops.value = []
+    currentStopIndex.value = 0
+    dirty.value = false
+    lastSavedAt.value = 'just now'
+    await loadCrawls()
+    emit('crawl-updated', crawl)
+  } catch (err: any) {
+    errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not create crawl'
+  } finally {
+    saving.value = false
+  }
+}
+
+async function loadCrawl(id: string) {
+  errorMessage.value = ''
+  try {
+    const crawl = await useAuthFetch<CrawlSummary & { stops: CrawlStop[] }>(`/api/crawls/${id}`)
+    activeCrawl.value = crawl
+    draftName.value = crawl.name
+    stops.value = (crawl.stops || []).map((s) => ({ ...s }))
+    currentStopIndex.value = crawl.currentStopIndex || 0
+    dirty.value = false
+    lastSavedAt.value = formatSavedTime(crawl.updatedAt)
+    emit('crawl-updated', crawl)
+  } catch (err: any) {
+    errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not load crawl'
+  }
+}
+
+async function saveMeta() {
+  if (!activeCrawl.value) return
+  const name = draftName.value.trim()
+  if (!name) return
+  saving.value = true
+  errorMessage.value = ''
+  try {
+    const crawl = await useAuthFetch<CrawlSummary>(`/api/crawls/${activeCrawl.value.id}`, {
+      method: 'PUT',
+      body: { name },
+    })
+    activeCrawl.value = { ...activeCrawl.value, name: crawl.name }
+    await loadCrawls()
+  } catch (err: any) {
+    errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not rename crawl'
+  } finally {
+    saving.value = false
+  }
+}
+
+async function saveCrawl() {
+  if (!activeCrawl.value) return
+  saving.value = true
+  errorMessage.value = ''
+  try {
+    const crawl = await useAuthFetch<CrawlSummary & { stops: CrawlStop[] }>(
+      `/api/crawls/${activeCrawl.value.id}/stops`,
+      {
+        method: 'PUT',
+        body: {
+          name: draftName.value.trim() || activeCrawl.value.name,
+          currentStopIndex: currentStopIndex.value,
+          stops: stops.value.map((s) => ({
+            venueId: s.venueId,
+            venueName: s.venueName,
+            latitude: s.latitude,
+            longitude: s.longitude,
+            notes: s.notes ?? null,
+          })),
+        },
+      },
+    )
+    activeCrawl.value = crawl
+    draftName.value = crawl.name
+    stops.value = (crawl.stops || []).map((s) => ({ ...s }))
+    currentStopIndex.value = crawl.currentStopIndex || 0
+    dirty.value = false
+    lastSavedAt.value = 'just now'
+    await loadCrawls()
+    emit('crawl-updated', crawl)
+  } catch (err: any) {
+    errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not save crawl'
+  } finally {
+    saving.value = false
+  }
+}
+
+async function deleteCrawl(id: string) {
+  if (!confirm('Delete this pub crawl? This cannot be undone.')) return
+  deletingId.value = id
+  errorMessage.value = ''
+  try {
+    await useAuthFetch(`/api/crawls/${id}`, { method: 'DELETE' })
+    if (activeCrawl.value?.id === id) startFresh()
+    await loadCrawls()
+  } catch (err: any) {
+    errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not delete crawl'
+  } finally {
+    deletingId.value = null
+  }
+}
+
+function addManualStop() {
+  const name = manualName.value.trim()
+  if (!name || !activeCrawl.value) return
+  stops.value.push({
+    venueId: null,
+    venueName: name,
+    latitude: null,
+    longitude: null,
+  })
+  manualName.value = ''
+  markDirty()
+}
+
+/** Called from the map page when the user adds a venue from the modal. */
+function addVenueStop(venue: {
+  id: number
+  name: string
+  lat: number | null
+  lng: number | null
+}) {
+  if (!activeCrawl.value) {
+    errorMessage.value = 'Create or open a crawl first, then add pubs.'
+    return false
+  }
+  if (venue.id && stops.value.some((s) => s.venueId === venue.id)) {
+    errorMessage.value = 'That pub is already on this crawl.'
+    return false
+  }
+  stops.value.push({
+    venueId: venue.id || null,
+    venueName: venue.name,
+    latitude: venue.lat,
+    longitude: venue.lng,
+  })
+  markDirty()
+  errorMessage.value = ''
+  return true
+}
+
+function removeStop(index: number) {
+  stops.value.splice(index, 1)
+  if (currentStopIndex.value >= stops.value.length) {
+    currentStopIndex.value = Math.max(0, stops.value.length - 1)
+  }
+  markDirty()
+}
+
+function setProgress(index: number) {
+  if (index < 0 || index >= stops.value.length) return
+  currentStopIndex.value = index
+  markDirty()
+}
+
+function onDragStart(index: number, event: DragEvent) {
+  dragIndex.value = index
+  event.dataTransfer?.setData('text/plain', String(index))
+  if (event.dataTransfer) event.dataTransfer.effectAllowed = 'move'
+}
+
+function onDragEnd() {
+  dragIndex.value = null
+  dropIndex.value = null
+}
+
+function onDragOver(index: number) {
+  dropIndex.value = index
+}
+
+function onDragLeave(index: number) {
+  if (dropIndex.value === index) dropIndex.value = null
+}
+
+function onDrop(toIndex: number) {
+  const fromIndex = dragIndex.value
+  dragIndex.value = null
+  dropIndex.value = null
+  if (fromIndex == null || fromIndex === toIndex) return
+
+  const next = stops.value.slice()
+  const [moved] = next.splice(fromIndex, 1)
+  next.splice(toIndex, 0, moved)
+  stops.value = next
+
+  // Keep "you are here" attached to the same stop after reorder
+  if (currentStopIndex.value === fromIndex) {
+    currentStopIndex.value = toIndex
+  } else if (fromIndex < currentStopIndex.value && toIndex >= currentStopIndex.value) {
+    currentStopIndex.value -= 1
+  } else if (fromIndex > currentStopIndex.value && toIndex <= currentStopIndex.value) {
+    currentStopIndex.value += 1
+  }
+
+  markDirty()
+}
+
+function formatSavedTime(iso: string) {
+  try {
+    return new Date(iso).toLocaleString()
+  } catch {
+    return iso
+  }
+}
+
+defineExpose({
+  addVenueStop,
+  activeCrawl,
+  hasActiveCrawl: computed(() => !!activeCrawl.value),
+})
+
+onMounted(async () => {
+  await initializeAuth()
+  if (isLoggedIn.value) await loadCrawls()
+})
+
+watch(isLoggedIn, async (loggedIn) => {
+  if (loggedIn) await loadCrawls()
+  else {
+    crawls.value = []
+    startFresh()
+  }
+})
+</script>

--- a/pages/map/index.vue
+++ b/pages/map/index.vue
@@ -1,17 +1,28 @@
 <template>
   <div>
-    <div class="flex justify-between w-full text-xl items-center container mx-auto py-3">
-      {{ venueName }}
-      <USelect
-        class="content-center"
-        icon="i-heroicons-map-pin-20-solid"
-        color="white"
-        size="sm"
-        :options="cityNames"
-        placeholder="Search by city..."
-        v-model="selectedCity"
-        @change="searchCity(selectedCity)"
-      />
+    <div class="flex justify-between w-full text-xl items-center container mx-auto py-3 gap-3 flex-wrap">
+      <span>{{ venueName }}</span>
+      <div class="flex items-center gap-2 flex-wrap">
+        <UButton
+          v-if="isLoggedIn"
+          size="sm"
+          color="amber"
+          variant="soft"
+          icon="i-heroicons-map-20-solid"
+          :label="crawlPanelLabel"
+          @click="openCrawlBuilder"
+        />
+        <USelect
+          class="content-center"
+          icon="i-heroicons-map-pin-20-solid"
+          color="white"
+          size="sm"
+          :options="cityNames"
+          placeholder="Search by city..."
+          v-model="selectedCity"
+          @change="searchCity(selectedCity)"
+        />
+      </div>
     </div>
     <div class="bg-gray-100 border-t">
       <venue-namesList class="h-full" :venuenames="venueStore.names" @venue-name="venueNameSelected" />
@@ -63,6 +74,14 @@
           @close="isOpenLeft.slideover = false"
         />
       </div>
+    </USlideover>
+    <USlideover v-model="isCrawlBuilderOpen" side="left" :ui="{ width: 'w-screen max-w-md' }">
+      <MapPubCrawlBuilder
+        v-if="isLoggedIn"
+        ref="crawlBuilderRef"
+        @close="isCrawlBuilderOpen = false"
+        @crawl-updated="onCrawlUpdated"
+      />
     </USlideover>
     <UModal v-model="isVenueModalOpen">
       <UCard v-if="selectedVenue" :ui="{ ring: '', divide: 'divide-y divide-gray-100 dark:divide-gray-800' }">
@@ -146,7 +165,18 @@
               label="Events"
               @click="openSelectedVenueEvents"
             />
+            <UButton
+              v-if="isLoggedIn"
+              color="amber"
+              variant="soft"
+              icon="i-heroicons-plus-20-solid"
+              :label="addToCrawlLabel"
+              @click="addSelectedVenueToCrawl"
+            />
           </div>
+          <p v-if="crawlAddMessage" class="text-sm text-emerald-700 dark:text-emerald-400">
+            {{ crawlAddMessage }}
+          </p>
         </div>
       </UCard>
     </UModal>
@@ -169,9 +199,87 @@ const venueStore = useVenueStore()
 const eventStore = useEventStore()
 const mapboxToken = useMapboxToken()
 const config = useRuntimeConfig()
+const { isLoggedIn, initializeAuth } = useAuth()
 
 const selectedCity = ref('')
 const cityNames = computed(() => eventStore.cities.map((city) => city.name))
+
+const isCrawlBuilderOpen = ref(false)
+const crawlBuilderRef = ref<{
+  addVenueStop: (venue: { id: number; name: string; lat: number | null; lng: number | null }) => boolean
+  activeCrawl: { value?: { name?: string } | null } | { name?: string } | null
+  hasActiveCrawl?: { value: boolean } | boolean
+} | null>(null)
+const activeCrawlName = ref('')
+const crawlAddMessage = ref('')
+let crawlAddMessageTimeout: ReturnType<typeof setTimeout> | null = null
+
+const crawlButtonLabel = computed(() =>
+  activeCrawlName.value ? `Pub crawl · ${activeCrawlName.value}` : 'Pub crawl',
+)
+const addToCrawlLabel = computed(() =>
+  activeCrawlName.value ? `Add to ${activeCrawlName.value}` : 'Add to crawl',
+)
+
+function openCrawlBuilder() {
+  isCrawlBuilderOpen.value = true
+  crawlAddMessage.value = ''
+}
+
+function onCrawlUpdated(crawl: { name?: string } | null) {
+  activeCrawlName.value = crawl?.name || ''
+}
+
+function addSelectedVenueToCrawl() {
+  if (!selectedVenue.value) return
+  crawlAddMessage.value = ''
+
+  const tryAdd = (attemptsLeft: number) => {
+    const builder = crawlBuilderRef.value
+    if (!builder?.addVenueStop) {
+      if (attemptsLeft > 0) {
+        requestAnimationFrame(() => tryAdd(attemptsLeft - 1))
+      } else {
+        crawlAddMessage.value = 'Open the pub crawl builder and create or load a crawl first.'
+      }
+      return
+    }
+
+    const active = unwrapRef(builder.activeCrawl)
+    if (!active) {
+      crawlAddMessage.value = 'Create or open a crawl in the builder, then add this pub.'
+      return
+    }
+
+    const ok = builder.addVenueStop({
+      id: selectedVenue.value!.id,
+      name: selectedVenue.value!.name,
+      lat: selectedVenue.value!.lat,
+      lng: selectedVenue.value!.lng,
+    })
+
+    if (ok) {
+      crawlAddMessage.value = `Added ${selectedVenue.value!.name} to your crawl. Remember to save.`
+      if (crawlAddMessageTimeout) clearTimeout(crawlAddMessageTimeout)
+      crawlAddMessageTimeout = setTimeout(() => {
+        crawlAddMessage.value = ''
+      }, 4000)
+    } else {
+      // Builder sets its own error (e.g. duplicate); surface a short cue here too
+      crawlAddMessage.value = 'Could not add this pub — check the crawl builder panel.'
+    }
+  }
+
+  if (!isCrawlBuilderOpen.value) isCrawlBuilderOpen.value = true
+  nextTick(() => tryAdd(12))
+}
+
+function unwrapRef<T>(value: { value?: T } | T | null | undefined): T | null | undefined {
+  if (value && typeof value === 'object' && 'value' in (value as object)) {
+    return (value as { value: T }).value
+  }
+  return value as T | null | undefined
+}
 
 const isOpenRight = reactive({
   slideover: false,
@@ -238,6 +346,7 @@ onMounted(async () => {
   desktopMediaQuery = window.matchMedia('(min-width: 768px)')
   updateDesktopViewport()
   desktopMediaQuery.addEventListener('change', updateDesktopViewport)
+  void initializeAuth()
   void eventStore.fetchCities()
   void loadFilterData()
   await createMap()
@@ -763,6 +872,7 @@ function updateDesktopViewport() {
 
 onBeforeUnmount(() => {
   if (popupTimeout) clearTimeout(popupTimeout)
+  if (crawlAddMessageTimeout) clearTimeout(crawlAddMessageTimeout)
   desktopMediaQuery?.removeEventListener('change', updateDesktopViewport)
   popup?.remove()
   map.value?.remove()

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,6 +42,7 @@ model Venue {
   events              Event[]
   claim               VenueClaim?
   profile             VenueProfile?
+  crawlStops          UkpubsCrawlStop[]
 }
 
 model Organisation {
@@ -203,4 +204,38 @@ model TownImage {
   updatedAt   DateTime @updatedAt @map("updated_at")
 
   @@map("town_images")
+}
+
+/// Saved pub crawl for a logged-in user (table: ukpubs_crawls)
+model UkpubsCrawl {
+  id               String            @id @default(uuid())
+  userId           String            @map("user_id")
+  name             String
+  currentStopIndex Int               @default(0) @map("current_stop_index")
+  createdAt        DateTime          @default(now()) @map("created_at")
+  updatedAt        DateTime          @updatedAt @map("updated_at")
+  stops            UkpubsCrawlStop[]
+
+  @@index([userId])
+  @@index([userId, updatedAt(sort: Desc)])
+  @@map("ukpubs_crawls")
+}
+
+/// Ordered stop within a pub crawl (table: ukpubs_crawl_stops)
+model UkpubsCrawlStop {
+  id        String      @id @default(uuid())
+  crawlId   String      @map("crawl_id")
+  venueId   Int?        @map("venue_id")
+  venueName String      @map("venue_name")
+  latitude  Float?
+  longitude Float?
+  sortOrder Int         @default(0) @map("sort_order")
+  notes     String?
+  createdAt DateTime    @default(now()) @map("created_at")
+  crawl     UkpubsCrawl @relation(fields: [crawlId], references: [id], onDelete: Cascade)
+  venue     Venue?      @relation(fields: [venueId], references: [id], onDelete: SetNull)
+
+  @@index([crawlId, sortOrder])
+  @@index([venueId])
+  @@map("ukpubs_crawl_stops")
 }

--- a/scripts/sql/ukpubs_pub_crawls.sql
+++ b/scripts/sql/ukpubs_pub_crawls.sql
@@ -1,22 +1,20 @@
 -- UK Pubs: pub crawl builder tables
 -- =============================================================================
--- Run this manually in the Supabase SQL editor (or any Postgres client).
--- Do NOT rely on Prisma migrate for these tables unless you choose to later.
+-- Run this in the Supabase SQL editor (full script in one go).
 --
 -- Tables (prefixed ukpubs_):
---   ukpubs_crawls       — one row per saved crawl (user_id = Supabase Auth UUID)
---   ukpubs_crawl_stops  — ordered stops (venue_id = "Venue".id, nullable for manual entries)
---
--- After running, redeploy / restart the app so Prisma can read the new tables.
+--   ukpubs_crawls       — user_id = Supabase Auth UUID
+--   ukpubs_crawl_stops  — venue_id = Venue.id (nullable for manual entries)
 -- =============================================================================
 
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
-CREATE TABLE IF NOT EXISTS ukpubs_crawls (
+-- 1) Parent crawl table
+CREATE TABLE IF NOT EXISTS public.ukpubs_crawls (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id TEXT NOT NULL,
     name TEXT NOT NULL,
-    -- 0-based index of the stop the user is currently at (progress through the crawl)
+    -- 0-based index of the stop the user is currently at
     current_stop_index INTEGER NOT NULL DEFAULT 0,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -26,16 +24,18 @@ CREATE TABLE IF NOT EXISTS ukpubs_crawls (
 );
 
 CREATE INDEX IF NOT EXISTS ukpubs_crawls_user_id_idx
-    ON ukpubs_crawls (user_id);
+    ON public.ukpubs_crawls (user_id);
 
 CREATE INDEX IF NOT EXISTS ukpubs_crawls_user_updated_idx
-    ON ukpubs_crawls (user_id, updated_at DESC);
+    ON public.ukpubs_crawls (user_id, updated_at DESC);
 
-CREATE TABLE IF NOT EXISTS ukpubs_crawl_stops (
+-- 2) Stops table
+-- venue_id is intentionally NOT a DB foreign key so this still works if the
+-- Venue table name/schema differs; the app still stores Venue.id here.
+CREATE TABLE IF NOT EXISTS public.ukpubs_crawl_stops (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    crawl_id UUID NOT NULL REFERENCES ukpubs_crawls (id) ON DELETE CASCADE,
-    -- Null when the stop was typed in manually (not picked from the map / Venue table)
-    venue_id INTEGER NULL REFERENCES "Venue" (id) ON DELETE SET NULL,
+    crawl_id UUID NOT NULL,
+    venue_id INTEGER NULL,
     venue_name TEXT NOT NULL,
     latitude DOUBLE PRECISION NULL,
     longitude DOUBLE PRECISION NULL,
@@ -47,18 +47,30 @@ CREATE TABLE IF NOT EXISTS ukpubs_crawl_stops (
     CONSTRAINT ukpubs_crawl_stops_sort_nonneg CHECK (sort_order >= 0)
 );
 
+-- Add crawl FK only if missing (safe to re-run)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'ukpubs_crawl_stops_crawl_id_fkey'
+    ) THEN
+        ALTER TABLE public.ukpubs_crawl_stops
+            ADD CONSTRAINT ukpubs_crawl_stops_crawl_id_fkey
+            FOREIGN KEY (crawl_id)
+            REFERENCES public.ukpubs_crawls (id)
+            ON DELETE CASCADE;
+    END IF;
+END $$;
+
 CREATE INDEX IF NOT EXISTS ukpubs_crawl_stops_crawl_id_idx
-    ON ukpubs_crawl_stops (crawl_id, sort_order);
+    ON public.ukpubs_crawl_stops (crawl_id, sort_order);
 
 CREATE INDEX IF NOT EXISTS ukpubs_crawl_stops_venue_id_idx
-    ON ukpubs_crawl_stops (venue_id);
+    ON public.ukpubs_crawl_stops (venue_id);
 
-CREATE INDEX IF NOT EXISTS ukpubs_crawl_stops_user_venue_idx
-    ON ukpubs_crawl_stops (venue_id)
-    WHERE venue_id IS NOT NULL;
-
--- Keep updated_at fresh on crawl row changes
-CREATE OR REPLACE FUNCTION ukpubs_crawls_set_updated_at()
+-- 3) updated_at trigger on crawls
+CREATE OR REPLACE FUNCTION public.ukpubs_crawls_set_updated_at()
 RETURNS TRIGGER AS $$
 BEGIN
     NEW.updated_at = NOW();
@@ -66,25 +78,25 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-DROP TRIGGER IF EXISTS ukpubs_crawls_updated_at ON ukpubs_crawls;
+DROP TRIGGER IF EXISTS ukpubs_crawls_updated_at ON public.ukpubs_crawls;
 CREATE TRIGGER ukpubs_crawls_updated_at
-    BEFORE UPDATE ON ukpubs_crawls
+    BEFORE UPDATE ON public.ukpubs_crawls
     FOR EACH ROW
-    EXECUTE PROCEDURE ukpubs_crawls_set_updated_at();
+    EXECUTE PROCEDURE public.ukpubs_crawls_set_updated_at();
 
--- Optional: bump parent crawl.updated_at when stops change
-CREATE OR REPLACE FUNCTION ukpubs_crawl_stops_touch_parent()
+-- 4) Touch parent crawl.updated_at when stops change
+CREATE OR REPLACE FUNCTION public.ukpubs_crawl_stops_touch_parent()
 RETURNS TRIGGER AS $$
 BEGIN
-    UPDATE ukpubs_crawls
+    UPDATE public.ukpubs_crawls
     SET updated_at = NOW()
     WHERE id = COALESCE(NEW.crawl_id, OLD.crawl_id);
     RETURN COALESCE(NEW, OLD);
 END;
 $$ LANGUAGE plpgsql;
 
-DROP TRIGGER IF EXISTS ukpubs_crawl_stops_touch_parent ON ukpubs_crawl_stops;
+DROP TRIGGER IF EXISTS ukpubs_crawl_stops_touch_parent ON public.ukpubs_crawl_stops;
 CREATE TRIGGER ukpubs_crawl_stops_touch_parent
-    AFTER INSERT OR UPDATE OR DELETE ON ukpubs_crawl_stops
+    AFTER INSERT OR UPDATE OR DELETE ON public.ukpubs_crawl_stops
     FOR EACH ROW
-    EXECUTE PROCEDURE ukpubs_crawl_stops_touch_parent();
+    EXECUTE PROCEDURE public.ukpubs_crawl_stops_touch_parent();

--- a/scripts/sql/ukpubs_pub_crawls.sql
+++ b/scripts/sql/ukpubs_pub_crawls.sql
@@ -1,0 +1,90 @@
+-- UK Pubs: pub crawl builder tables
+-- =============================================================================
+-- Run this manually in the Supabase SQL editor (or any Postgres client).
+-- Do NOT rely on Prisma migrate for these tables unless you choose to later.
+--
+-- Tables (prefixed ukpubs_):
+--   ukpubs_crawls       — one row per saved crawl (user_id = Supabase Auth UUID)
+--   ukpubs_crawl_stops  — ordered stops (venue_id = "Venue".id, nullable for manual entries)
+--
+-- After running, redeploy / restart the app so Prisma can read the new tables.
+-- =============================================================================
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS ukpubs_crawls (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    -- 0-based index of the stop the user is currently at (progress through the crawl)
+    current_stop_index INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT ukpubs_crawls_name_not_blank CHECK (char_length(trim(name)) > 0),
+    CONSTRAINT ukpubs_crawls_current_stop_nonneg CHECK (current_stop_index >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS ukpubs_crawls_user_id_idx
+    ON ukpubs_crawls (user_id);
+
+CREATE INDEX IF NOT EXISTS ukpubs_crawls_user_updated_idx
+    ON ukpubs_crawls (user_id, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS ukpubs_crawl_stops (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    crawl_id UUID NOT NULL REFERENCES ukpubs_crawls (id) ON DELETE CASCADE,
+    -- Null when the stop was typed in manually (not picked from the map / Venue table)
+    venue_id INTEGER NULL REFERENCES "Venue" (id) ON DELETE SET NULL,
+    venue_name TEXT NOT NULL,
+    latitude DOUBLE PRECISION NULL,
+    longitude DOUBLE PRECISION NULL,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    notes TEXT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT ukpubs_crawl_stops_name_not_blank CHECK (char_length(trim(venue_name)) > 0),
+    CONSTRAINT ukpubs_crawl_stops_sort_nonneg CHECK (sort_order >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS ukpubs_crawl_stops_crawl_id_idx
+    ON ukpubs_crawl_stops (crawl_id, sort_order);
+
+CREATE INDEX IF NOT EXISTS ukpubs_crawl_stops_venue_id_idx
+    ON ukpubs_crawl_stops (venue_id);
+
+CREATE INDEX IF NOT EXISTS ukpubs_crawl_stops_user_venue_idx
+    ON ukpubs_crawl_stops (venue_id)
+    WHERE venue_id IS NOT NULL;
+
+-- Keep updated_at fresh on crawl row changes
+CREATE OR REPLACE FUNCTION ukpubs_crawls_set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS ukpubs_crawls_updated_at ON ukpubs_crawls;
+CREATE TRIGGER ukpubs_crawls_updated_at
+    BEFORE UPDATE ON ukpubs_crawls
+    FOR EACH ROW
+    EXECUTE PROCEDURE ukpubs_crawls_set_updated_at();
+
+-- Optional: bump parent crawl.updated_at when stops change
+CREATE OR REPLACE FUNCTION ukpubs_crawl_stops_touch_parent()
+RETURNS TRIGGER AS $$
+BEGIN
+    UPDATE ukpubs_crawls
+    SET updated_at = NOW()
+    WHERE id = COALESCE(NEW.crawl_id, OLD.crawl_id);
+    RETURN COALESCE(NEW, OLD);
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS ukpubs_crawl_stops_touch_parent ON ukpubs_crawl_stops;
+CREATE TRIGGER ukpubs_crawl_stops_touch_parent
+    AFTER INSERT OR UPDATE OR DELETE ON ukpubs_crawl_stops
+    FOR EACH ROW
+    EXECUTE PROCEDURE ukpubs_crawl_stops_touch_parent();

--- a/server/api/crawls/[id].ts
+++ b/server/api/crawls/[id].ts
@@ -1,0 +1,60 @@
+import { prisma } from '../../utils/prisma'
+import { requireAuth } from '../../utils/require-auth'
+import { getCrawlForUser, serializeCrawl } from '../../utils/crawls'
+
+export default defineEventHandler(async (event) => {
+  const user = await requireAuth(event)
+  const crawlId = getRouterParam(event, 'id')
+  if (!crawlId) {
+    throw createError({ statusCode: 400, statusMessage: 'Crawl id is required' })
+  }
+
+  const method = event.method
+
+  if (method === 'GET') {
+    const crawl = await getCrawlForUser(crawlId, user.id)
+    return serializeCrawl(crawl)
+  }
+
+  if (method === 'PUT' || method === 'PATCH') {
+    const existing = await getCrawlForUser(crawlId, user.id)
+    const body = await readBody(event)
+
+    const data: { name?: string; currentStopIndex?: number } = {}
+
+    if (body?.name != null) {
+      const name = String(body.name).trim()
+      if (!name) {
+        throw createError({ statusCode: 400, statusMessage: 'Crawl name cannot be empty' })
+      }
+      data.name = name
+    }
+
+    if (body?.currentStopIndex != null) {
+      const index = Number.parseInt(String(body.currentStopIndex), 10)
+      if (!Number.isFinite(index) || index < 0) {
+        throw createError({ statusCode: 400, statusMessage: 'Invalid currentStopIndex' })
+      }
+      const maxIndex = Math.max(0, existing.stops.length - 1)
+      data.currentStopIndex = Math.min(index, maxIndex)
+    }
+
+    const crawl = await prisma.ukpubsCrawl.update({
+      where: { id: crawlId },
+      data,
+      include: {
+        stops: { orderBy: { sortOrder: 'asc' } },
+      },
+    })
+
+    return serializeCrawl(crawl)
+  }
+
+  if (method === 'DELETE') {
+    await getCrawlForUser(crawlId, user.id)
+    await prisma.ukpubsCrawl.delete({ where: { id: crawlId } })
+    return { ok: true }
+  }
+
+  throw createError({ statusCode: 405, statusMessage: 'Method not allowed' })
+})

--- a/server/api/crawls/[id]/stops.ts
+++ b/server/api/crawls/[id]/stops.ts
@@ -1,0 +1,152 @@
+import { prisma } from '../../../utils/prisma'
+import { requireAuth } from '../../../utils/require-auth'
+import {
+  getCrawlForUser,
+  parseOptionalCoord,
+  serializeCrawl,
+  serializeStop,
+} from '../../../utils/crawls'
+
+type IncomingStop = {
+  id?: string
+  venueId?: number | null
+  venueName?: string
+  latitude?: number | null
+  longitude?: number | null
+  notes?: string | null
+}
+
+export default defineEventHandler(async (event) => {
+  const user = await requireAuth(event)
+  const crawlId = getRouterParam(event, 'id')
+  if (!crawlId) {
+    throw createError({ statusCode: 400, statusMessage: 'Crawl id is required' })
+  }
+
+  const method = event.method
+
+  if (method === 'POST') {
+    const crawl = await getCrawlForUser(crawlId, user.id)
+    const body = await readBody(event)
+    const stop = await resolveStopInput(body)
+
+    const created = await prisma.ukpubsCrawlStop.create({
+      data: {
+        crawlId,
+        venueId: stop.venueId,
+        venueName: stop.venueName,
+        latitude: stop.latitude,
+        longitude: stop.longitude,
+        notes: stop.notes,
+        sortOrder: crawl.stops.length,
+      },
+    })
+
+    return serializeStop(created)
+  }
+
+  if (method === 'PUT') {
+    await getCrawlForUser(crawlId, user.id)
+    const body = await readBody(event)
+    const stopsInput = Array.isArray(body?.stops) ? (body.stops as IncomingStop[]) : null
+    if (!stopsInput) {
+      throw createError({ statusCode: 400, statusMessage: 'stops array is required' })
+    }
+
+    const resolved = await Promise.all(stopsInput.map((item) => resolveStopInput(item)))
+
+    const crawl = await prisma.$transaction(async (tx) => {
+      await tx.ukpubsCrawlStop.deleteMany({ where: { crawlId } })
+
+      if (resolved.length) {
+        await tx.ukpubsCrawlStop.createMany({
+          data: resolved.map((stop, index) => ({
+            id: crypto.randomUUID(),
+            crawlId,
+            venueId: stop.venueId,
+            venueName: stop.venueName,
+            latitude: stop.latitude,
+            longitude: stop.longitude,
+            notes: stop.notes,
+            sortOrder: index,
+          })),
+        })
+      }
+
+      const currentStopIndex = Number.isFinite(Number(body?.currentStopIndex))
+        ? Math.max(0, Math.min(Number(body.currentStopIndex), Math.max(0, resolved.length - 1)))
+        : 0
+
+      return tx.ukpubsCrawl.update({
+        where: { id: crawlId },
+        data: {
+          ...(body?.name != null ? { name: String(body.name).trim() || undefined } : {}),
+          currentStopIndex: resolved.length === 0 ? 0 : currentStopIndex,
+        },
+        include: {
+          stops: { orderBy: { sortOrder: 'asc' } },
+        },
+      })
+    })
+
+    return serializeCrawl(crawl)
+  }
+
+  throw createError({ statusCode: 405, statusMessage: 'Method not allowed' })
+})
+
+async function resolveStopInput(input: IncomingStop | null | undefined) {
+  const venueId = parseOptionalVenueId(input?.venueId)
+
+  let venueName = String(input?.venueName || '').trim()
+  let latitude = parseOptionalCoord(input?.latitude)
+  let longitude = parseOptionalCoord(input?.longitude)
+  const notes = input?.notes == null ? null : String(input.notes).trim() || null
+
+  if (venueId != null) {
+    const venue = await prisma.venue.findUnique({
+      where: { id: venueId },
+      select: {
+        id: true,
+        venuename: true,
+        latitude: true,
+        longitude: true,
+      },
+    })
+    if (!venue) {
+      throw createError({ statusCode: 404, statusMessage: `Venue ${venueId} not found` })
+    }
+    if (!venueName) venueName = venue.venuename
+    if (latitude == null) latitude = parseOptionalCoord(venue.latitude)
+    if (longitude == null) longitude = parseOptionalCoord(venue.longitude)
+
+    return {
+      venueId: venue.id,
+      venueName,
+      latitude,
+      longitude,
+      notes,
+    }
+  }
+
+  if (!venueName) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Each stop needs a venueId or venueName',
+    })
+  }
+
+  return {
+    venueId: null,
+    venueName,
+    latitude,
+    longitude,
+    notes,
+  }
+}
+
+function parseOptionalVenueId(value: unknown): number | null {
+  if (value == null || value === '') return null
+  const n = Number.parseInt(String(value), 10)
+  return Number.isFinite(n) && n > 0 ? n : null
+}

--- a/server/api/crawls/[id]/stops/[stopId].ts
+++ b/server/api/crawls/[id]/stops/[stopId].ts
@@ -1,0 +1,52 @@
+import { prisma } from '../../../../utils/prisma'
+import { requireAuth } from '../../../../utils/require-auth'
+import { getCrawlForUser } from '../../../../utils/crawls'
+
+export default defineEventHandler(async (event) => {
+  const user = await requireAuth(event)
+  const crawlId = getRouterParam(event, 'id')
+  const stopId = getRouterParam(event, 'stopId')
+
+  if (!crawlId || !stopId) {
+    throw createError({ statusCode: 400, statusMessage: 'Crawl id and stop id are required' })
+  }
+
+  if (event.method !== 'DELETE') {
+    throw createError({ statusCode: 405, statusMessage: 'Method not allowed' })
+  }
+
+  const crawl = await getCrawlForUser(crawlId, user.id)
+  const stop = crawl.stops.find((s) => s.id === stopId)
+  if (!stop) {
+    throw createError({ statusCode: 404, statusMessage: 'Stop not found' })
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await tx.ukpubsCrawlStop.delete({ where: { id: stopId } })
+
+    const remaining = crawl.stops
+      .filter((s) => s.id !== stopId)
+      .sort((a, b) => a.sortOrder - b.sortOrder)
+
+    for (let i = 0; i < remaining.length; i++) {
+      if (remaining[i].sortOrder !== i) {
+        await tx.ukpubsCrawlStop.update({
+          where: { id: remaining[i].id },
+          data: { sortOrder: i },
+        })
+      }
+    }
+
+    const maxIndex = Math.max(0, remaining.length - 1)
+    const nextIndex = remaining.length === 0
+      ? 0
+      : Math.min(crawl.currentStopIndex, maxIndex)
+
+    await tx.ukpubsCrawl.update({
+      where: { id: crawlId },
+      data: { currentStopIndex: nextIndex },
+    })
+  })
+
+  return { ok: true }
+})

--- a/server/api/crawls/index.ts
+++ b/server/api/crawls/index.ts
@@ -1,0 +1,42 @@
+import { prisma } from '../../utils/prisma'
+import { requireAuth } from '../../utils/require-auth'
+import { serializeCrawl } from '../../utils/crawls'
+
+export default defineEventHandler(async (event) => {
+  const user = await requireAuth(event)
+  const method = event.method
+
+  if (method === 'GET') {
+    const crawls = await prisma.ukpubsCrawl.findMany({
+      where: { userId: user.id },
+      include: {
+        stops: { orderBy: { sortOrder: 'asc' } },
+      },
+      orderBy: { updatedAt: 'desc' },
+    })
+    return crawls.map(serializeCrawl)
+  }
+
+  if (method === 'POST') {
+    const body = await readBody(event)
+    const name = String(body?.name || '').trim()
+    if (!name) {
+      throw createError({ statusCode: 400, statusMessage: 'Crawl name is required' })
+    }
+
+    const crawl = await prisma.ukpubsCrawl.create({
+      data: {
+        userId: user.id,
+        name,
+        currentStopIndex: 0,
+      },
+      include: {
+        stops: { orderBy: { sortOrder: 'asc' } },
+      },
+    })
+
+    return serializeCrawl(crawl)
+  }
+
+  throw createError({ statusCode: 405, statusMessage: 'Method not allowed' })
+})

--- a/server/utils/crawls.ts
+++ b/server/utils/crawls.ts
@@ -1,0 +1,79 @@
+import type { UkpubsCrawl, UkpubsCrawlStop } from '@prisma/client'
+import { prisma } from './prisma'
+
+export type CrawlStopDto = {
+  id: string
+  crawlId: string
+  venueId: number | null
+  venueName: string
+  latitude: number | null
+  longitude: number | null
+  sortOrder: number
+  notes: string | null
+  createdAt: string
+}
+
+export type CrawlDto = {
+  id: string
+  userId: string
+  name: string
+  currentStopIndex: number
+  createdAt: string
+  updatedAt: string
+  stops: CrawlStopDto[]
+  stopCount: number
+}
+
+export function serializeStop(stop: UkpubsCrawlStop): CrawlStopDto {
+  return {
+    id: stop.id,
+    crawlId: stop.crawlId,
+    venueId: stop.venueId,
+    venueName: stop.venueName,
+    latitude: stop.latitude,
+    longitude: stop.longitude,
+    sortOrder: stop.sortOrder,
+    notes: stop.notes,
+    createdAt: stop.createdAt.toISOString(),
+  }
+}
+
+export function serializeCrawl(
+  crawl: UkpubsCrawl & { stops?: UkpubsCrawlStop[] },
+): CrawlDto {
+  const stops = (crawl.stops || [])
+    .slice()
+    .sort((a, b) => a.sortOrder - b.sortOrder)
+    .map(serializeStop)
+
+  return {
+    id: crawl.id,
+    userId: crawl.userId,
+    name: crawl.name,
+    currentStopIndex: crawl.currentStopIndex,
+    createdAt: crawl.createdAt.toISOString(),
+    updatedAt: crawl.updatedAt.toISOString(),
+    stops,
+    stopCount: stops.length,
+  }
+}
+
+export async function getCrawlForUser(crawlId: string, userId: string) {
+  const crawl = await prisma.ukpubsCrawl.findFirst({
+    where: { id: crawlId, userId },
+    include: {
+      stops: { orderBy: { sortOrder: 'asc' } },
+    },
+  })
+  if (!crawl) {
+    throw createError({ statusCode: 404, statusMessage: 'Pub crawl not found' })
+  }
+  return crawl
+}
+
+export function parseOptionalCoord(value: unknown): number | null {
+  if (value == null || value === '') return null
+  const n = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(n) || n === 0) return null
+  return n
+}

--- a/utils/crawl-distance.ts
+++ b/utils/crawl-distance.ts
@@ -1,0 +1,70 @@
+/** Approx walking distance helpers for pub crawl legs (client + server safe). */
+
+const EARTH_RADIUS_MILES = 3958.7613
+const WALKING_MPH = 3.1
+/** Typical walking routes are longer than crow-flies; ~1.25x is a common urban factor. */
+const WALK_ROUTE_FACTOR = 1.25
+
+export function haversineMiles(lat1: number, lon1: number, lat2: number, lon2: number) {
+  const toRad = (d: number) => (d * Math.PI) / 180
+  const a =
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.cos(toRad(lon2 - lon1))
+    + Math.sin(toRad(lat1)) * Math.sin(toRad(lat2))
+  return EARTH_RADIUS_MILES * Math.acos(Math.min(1, Math.max(-1, a)))
+}
+
+export function estimateWalkingMiles(lat1: number, lon1: number, lat2: number, lon2: number) {
+  return haversineMiles(lat1, lon1, lat2, lon2) * WALK_ROUTE_FACTOR
+}
+
+export function estimateWalkingMinutes(miles: number) {
+  return Math.round((miles / WALKING_MPH) * 60)
+}
+
+export function formatWalkingDistance(miles: number) {
+  if (!Number.isFinite(miles) || miles < 0) return ''
+  if (miles < 0.1) {
+    const yards = Math.round(miles * 1760)
+    return `${yards} yd walk`
+  }
+  const mins = estimateWalkingMinutes(miles)
+  const milesLabel = miles < 10 ? miles.toFixed(1) : Math.round(miles).toString()
+  return `~${milesLabel} mi · ${mins} min walk`
+}
+
+export type CrawlLeg = {
+  fromIndex: number
+  toIndex: number
+  miles: number | null
+  label: string
+}
+
+export function buildCrawlLegs(
+  stops: Array<{ latitude?: number | null; longitude?: number | null }>,
+): CrawlLeg[] {
+  const legs: CrawlLeg[] = []
+  for (let i = 0; i < stops.length - 1; i++) {
+    const a = stops[i]
+    const b = stops[i + 1]
+    const lat1 = a.latitude
+    const lon1 = a.longitude
+    const lat2 = b.latitude
+    const lon2 = b.longitude
+    if (
+      lat1 == null || lon1 == null || lat2 == null || lon2 == null
+      || !Number.isFinite(lat1) || !Number.isFinite(lon1)
+      || !Number.isFinite(lat2) || !Number.isFinite(lon2)
+    ) {
+      legs.push({ fromIndex: i, toIndex: i + 1, miles: null, label: 'Distance unknown' })
+      continue
+    }
+    const miles = estimateWalkingMiles(lat1, lon1, lat2, lon2)
+    legs.push({
+      fromIndex: i,
+      toIndex: i + 1,
+      miles,
+      label: formatWalkingDistance(miles),
+    })
+  }
+  return legs
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a **pub crawl builder** for logged-in users on `/map`:

- Create a named crawl, add pubs from the map modal or by typing a name
- Drag-and-drop reorder (stop 1 = start, last = finish)
- Estimated walking distance / time between consecutive stops
- Track progress (“you are here” / next pub) and save/load/delete crawls

## Database (manual)
Run this SQL in Supabase before using the feature:

`scripts/sql/ukpubs_pub_crawls.sql`

Tables:
- `ukpubs_crawls` — `user_id` (Supabase Auth UUID), name, `current_stop_index`
- `ukpubs_crawl_stops` — `crawl_id`, `venue_id` (nullable for manual entries; no DB FK to Venue), `venue_name`, coords, `sort_order`

Prisma models mirror these tables so the APIs work once the SQL is applied.

**If a previous run failed**, re-run the full updated script — it is safe to re-run (`IF NOT EXISTS` / conditional FK).

## API
- `GET/POST /api/crawls`
- `GET/PUT/DELETE /api/crawls/:id`
- `POST/PUT /api/crawls/:id/stops`
- `DELETE /api/crawls/:id/stops/:stopId`

All require a Bearer token (existing `requireAuth` / `useAuthFetch`).

## UI
- **Pub crawl** button on the map toolbar (logged-in only)
- Left slideover builder panel
- **Add to crawl** on the venue detail modal
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f115d295-b0d1-4947-b408-4e43bc3859e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f115d295-b0d1-4947-b408-4e43bc3859e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

