### PR TITLE
Fix pub crawl add + venue search autocomplete

### DIFF
--- a/components/map/PubCrawlBuilder.vue
+++ b/components/map/PubCrawlBuilder.vue
@@ -26,7 +26,6 @@
         @close="errorMessage = ''"
       />
 
-      <!-- Saved crawls -->
       <section class="space-y-2">
         <div class="flex items-center justify-between gap-2">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">Your crawls</h3>
@@ -54,7 +53,7 @@
             <button
               type="button"
               class="min-w-0 flex-1 text-left"
-              @click="loadCrawl(crawl.id)"
+              @click="selectCrawl(crawl.id)"
             >
               <span class="block truncate font-medium text-gray-900 dark:text-white">{{ crawl.name }}</span>
               <span class="text-xs text-gray-500">
@@ -71,14 +70,13 @@
               icon="i-heroicons-trash-20-solid"
               aria-label="Delete crawl"
               :loading="deletingId === crawl.id"
-              @click="deleteCrawl(crawl.id)"
+              @click="onDeleteCrawl(crawl.id)"
             />
           </li>
         </ul>
         <p v-else class="text-sm text-gray-500">No saved crawls yet. Create one below.</p>
       </section>
 
-      <!-- Create / rename -->
       <section class="space-y-2 rounded-md border border-gray-200 p-3 dark:border-gray-800">
         <label class="block text-sm font-medium text-gray-900 dark:text-white">
           {{ activeCrawl ? 'Crawl name' : 'New crawl name' }}
@@ -89,7 +87,7 @@
             class="flex-1"
             placeholder="e.g. Friday night in Liverpool"
             maxlength="120"
-            @keydown.enter.prevent="activeCrawl ? saveMeta() : createCrawl()"
+            @keydown.enter.prevent="activeCrawl ? onSaveMeta() : onCreateCrawl()"
           />
           <UButton
             v-if="!activeCrawl"
@@ -97,7 +95,7 @@
             :loading="saving"
             :disabled="!draftName.trim()"
             label="Create"
-            @click="createCrawl"
+            @click="onCreateCrawl"
           />
           <UButton
             v-else
@@ -106,7 +104,7 @@
             :loading="saving"
             :disabled="!draftName.trim() || draftName.trim() === activeCrawl.name"
             label="Rename"
-            @click="saveMeta"
+            @click="onSaveMeta"
           />
         </div>
         <UButton
@@ -115,12 +113,11 @@
           color="gray"
           variant="link"
           label="Start a new crawl"
-          @click="startFresh"
+          @click="onStartFresh"
         />
       </section>
 
       <template v-if="activeCrawl">
-        <!-- Manual add -->
         <section class="space-y-2">
           <h3 class="text-sm font-semibold text-gray-900 dark:text-white">Add a pub</h3>
           <p class="text-xs text-gray-500">
@@ -132,7 +129,7 @@
               class="flex-1"
               placeholder="Type a pub name…"
               maxlength="200"
-              @keydown.enter.prevent="addManualStop"
+              @keydown.enter.prevent="onAddManual"
             />
             <UButton
               color="gray"
@@ -140,12 +137,11 @@
               :disabled="!manualName.trim() || addingStop"
               :loading="addingStop"
               label="Add"
-              @click="addManualStop"
+              @click="onAddManual"
             />
           </div>
         </section>
 
-        <!-- Ordered stops -->
         <section class="space-y-2">
           <div class="flex items-center justify-between gap-2">
             <h3 class="text-sm font-semibold text-gray-900 dark:text-white">
@@ -233,7 +229,7 @@
                       variant="ghost"
                       icon="i-heroicons-x-mark-20-solid"
                       aria-label="Remove stop"
-                      @click="removeStop(index)"
+                      @click="removeStopLocal(index)"
                     />
                   </div>
                 </div>
@@ -250,7 +246,6 @@
           </ol>
         </section>
 
-        <!-- Progress + save -->
         <section class="space-y-3 border-t border-gray-200 pt-3 dark:border-gray-800">
           <div v-if="stops.length" class="space-y-1">
             <div class="flex justify-between text-xs text-gray-500">
@@ -288,8 +283,8 @@
             color="amber"
             :loading="saving"
             :disabled="!dirty"
-            label="Save crawl"
-            @click="saveCrawl"
+            label="Save order & progress"
+            @click="onSaveCrawl"
           />
           <p v-if="lastSavedAt" class="text-center text-xs text-gray-500">
             Saved {{ lastSavedAt }}
@@ -301,257 +296,84 @@
 </template>
 
 <script setup lang="ts">
-import { buildCrawlLegs, formatWalkingDistance } from '@/utils/crawl-distance'
-
-export type CrawlStop = {
-  id?: string
-  venueId: number | null
-  venueName: string
-  latitude: number | null
-  longitude: number | null
-  notes?: string | null
-  sortOrder?: number
-}
-
-export type CrawlSummary = {
-  id: string
-  name: string
-  currentStopIndex: number
-  stopCount: number
-  updatedAt: string
-  stops?: CrawlStop[]
-}
-
 const emit = defineEmits<{
   close: []
-  'crawl-updated': [crawl: CrawlSummary | null]
+  'crawl-updated': [crawl: { id: string; name: string } | null]
 }>()
 
-const { isLoggedIn, initializeAuth } = useAuth()
+const {
+  crawls,
+  activeCrawl,
+  stops,
+  currentStopIndex,
+  draftName,
+  loadingList,
+  saving,
+  addingStop,
+  deletingId,
+  errorMessage,
+  dirty,
+  lastSavedAt,
+  totalWalkLabel,
+  progressPercent,
+  legLabel,
+  clearActive,
+  loadCrawls,
+  loadCrawl,
+  createCrawl,
+  saveMeta,
+  saveCrawl,
+  deleteCrawl,
+  addManualStop,
+  removeStopLocal,
+  setProgress,
+  reorderStops,
+  initialize,
+} = usePubCrawl()
 
-const crawls = ref<CrawlSummary[]>([])
-const activeCrawl = ref<CrawlSummary | null>(null)
-const stops = ref<CrawlStop[]>([])
-const currentStopIndex = ref(0)
-const draftName = ref('')
 const manualName = ref('')
-const loadingList = ref(false)
-const saving = ref(false)
-const addingStop = ref(false)
-const deletingId = ref<string | null>(null)
-const errorMessage = ref('')
-const dirty = ref(false)
-const lastSavedAt = ref('')
 const dragIndex = ref<number | null>(null)
 const dropIndex = ref<number | null>(null)
 
-const legs = computed(() => buildCrawlLegs(stops.value))
+watch(
+  activeCrawl,
+  (crawl) => {
+    emit('crawl-updated', crawl ? { id: crawl.id, name: crawl.name } : null)
+  },
+  { immediate: true },
+)
 
-const totalWalkLabel = computed(() => {
-  const miles = legs.value.reduce((sum, leg) => sum + (leg.miles ?? 0), 0)
-  if (!miles) return ''
-  return `Total ~${formatWalkingDistance(miles).replace(/^~/, '')}`
-})
-
-const progressPercent = computed(() => {
-  if (!stops.value.length) return 0
-  return Math.round(((currentStopIndex.value + 1) / stops.value.length) * 100)
-})
-
-function legLabel(fromIndex: number) {
-  return legs.value[fromIndex]?.label || 'Distance unknown'
+async function selectCrawl(id: string) {
+  await loadCrawl(id)
 }
 
-function markDirty() {
-  dirty.value = true
+async function onCreateCrawl() {
+  await createCrawl()
 }
 
-function startFresh() {
-  activeCrawl.value = null
-  stops.value = []
-  currentStopIndex.value = 0
-  draftName.value = ''
-  dirty.value = false
-  lastSavedAt.value = ''
-  emit('crawl-updated', null)
+async function onSaveMeta() {
+  await saveMeta()
 }
 
-async function loadCrawls() {
-  if (!isLoggedIn.value) return
-  loadingList.value = true
-  errorMessage.value = ''
-  try {
-    crawls.value = await useAuthFetch<CrawlSummary[]>('/api/crawls')
-  } catch (err: any) {
-    errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not load crawls'
-  } finally {
-    loadingList.value = false
-  }
+async function onSaveCrawl() {
+  await saveCrawl()
 }
 
-async function createCrawl() {
-  const name = draftName.value.trim()
-  if (!name) return
-  saving.value = true
-  errorMessage.value = ''
-  try {
-    const crawl = await useAuthFetch<CrawlSummary>('/api/crawls', {
-      method: 'POST',
-      body: { name },
-    })
-    activeCrawl.value = crawl
-    stops.value = []
-    currentStopIndex.value = 0
-    dirty.value = false
-    lastSavedAt.value = 'just now'
-    await loadCrawls()
-    emit('crawl-updated', crawl)
-  } catch (err: any) {
-    errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not create crawl'
-  } finally {
-    saving.value = false
-  }
-}
-
-async function loadCrawl(id: string) {
-  errorMessage.value = ''
-  try {
-    const crawl = await useAuthFetch<CrawlSummary & { stops: CrawlStop[] }>(`/api/crawls/${id}`)
-    activeCrawl.value = crawl
-    draftName.value = crawl.name
-    stops.value = (crawl.stops || []).map((s) => ({ ...s }))
-    currentStopIndex.value = crawl.currentStopIndex || 0
-    dirty.value = false
-    lastSavedAt.value = formatSavedTime(crawl.updatedAt)
-    emit('crawl-updated', crawl)
-  } catch (err: any) {
-    errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not load crawl'
-  }
-}
-
-async function saveMeta() {
-  if (!activeCrawl.value) return
-  const name = draftName.value.trim()
-  if (!name) return
-  saving.value = true
-  errorMessage.value = ''
-  try {
-    const crawl = await useAuthFetch<CrawlSummary>(`/api/crawls/${activeCrawl.value.id}`, {
-      method: 'PUT',
-      body: { name },
-    })
-    activeCrawl.value = { ...activeCrawl.value, name: crawl.name }
-    await loadCrawls()
-  } catch (err: any) {
-    errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not rename crawl'
-  } finally {
-    saving.value = false
-  }
-}
-
-async function saveCrawl() {
-  if (!activeCrawl.value) return
-  saving.value = true
-  errorMessage.value = ''
-  try {
-    const crawl = await useAuthFetch<CrawlSummary & { stops: CrawlStop[] }>(
-      `/api/crawls/${activeCrawl.value.id}/stops`,
-      {
-        method: 'PUT',
-        body: {
-          name: draftName.value.trim() || activeCrawl.value.name,
-          currentStopIndex: currentStopIndex.value,
-          stops: stops.value.map((s) => ({
-            venueId: s.venueId,
-            venueName: s.venueName,
-            latitude: s.latitude,
-            longitude: s.longitude,
-            notes: s.notes ?? null,
-          })),
-        },
-      },
-    )
-    activeCrawl.value = crawl
-    draftName.value = crawl.name
-    stops.value = (crawl.stops || []).map((s) => ({ ...s }))
-    currentStopIndex.value = crawl.currentStopIndex || 0
-    dirty.value = false
-    lastSavedAt.value = 'just now'
-    await loadCrawls()
-    emit('crawl-updated', crawl)
-  } catch (err: any) {
-    errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not save crawl'
-  } finally {
-    saving.value = false
-  }
-}
-
-async function deleteCrawl(id: string) {
+async function onDeleteCrawl(id: string) {
   if (!confirm('Delete this pub crawl? This cannot be undone.')) return
-  deletingId.value = id
-  errorMessage.value = ''
-  try {
-    await useAuthFetch(`/api/crawls/${id}`, { method: 'DELETE' })
-    if (activeCrawl.value?.id === id) startFresh()
-    await loadCrawls()
-  } catch (err: any) {
-    errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not delete crawl'
-  } finally {
-    deletingId.value = null
-  }
+  await deleteCrawl(id)
 }
 
-function addManualStop() {
+function onStartFresh() {
+  clearActive()
+  draftName.value = ''
+}
+
+async function onAddManual() {
   const name = manualName.value.trim()
-  if (!name || !activeCrawl.value) return
-  stops.value.push({
-    venueId: null,
-    venueName: name,
-    latitude: null,
-    longitude: null,
-  })
-  manualName.value = ''
-  markDirty()
-}
-
-/** Called from the map page when the user adds a venue from the modal. */
-function addVenueStop(venue: {
-  id: number
-  name: string
-  lat: number | null
-  lng: number | null
-}) {
-  if (!activeCrawl.value) {
-    errorMessage.value = 'Create or open a crawl first, then add pubs.'
-    return false
-  }
-  if (venue.id && stops.value.some((s) => s.venueId === venue.id)) {
-    errorMessage.value = 'That pub is already on this crawl.'
-    return false
-  }
-  stops.value.push({
-    venueId: venue.id || null,
-    venueName: venue.name,
-    latitude: venue.lat,
-    longitude: venue.lng,
-  })
-  markDirty()
-  errorMessage.value = ''
-  return true
-}
-
-function removeStop(index: number) {
-  stops.value.splice(index, 1)
-  if (currentStopIndex.value >= stops.value.length) {
-    currentStopIndex.value = Math.max(0, stops.value.length - 1)
-  }
-  markDirty()
-}
-
-function setProgress(index: number) {
-  if (index < 0 || index >= stops.value.length) return
-  currentStopIndex.value = index
-  markDirty()
+  if (!name) return
+  const ok = await addManualStop(name)
+  if (ok) manualName.value = ''
 }
 
 function onDragStart(index: number, event: DragEvent) {
@@ -578,48 +400,10 @@ function onDrop(toIndex: number) {
   dragIndex.value = null
   dropIndex.value = null
   if (fromIndex == null || fromIndex === toIndex) return
-
-  const next = stops.value.slice()
-  const [moved] = next.splice(fromIndex, 1)
-  next.splice(toIndex, 0, moved)
-  stops.value = next
-
-  // Keep "you are here" attached to the same stop after reorder
-  if (currentStopIndex.value === fromIndex) {
-    currentStopIndex.value = toIndex
-  } else if (fromIndex < currentStopIndex.value && toIndex >= currentStopIndex.value) {
-    currentStopIndex.value -= 1
-  } else if (fromIndex > currentStopIndex.value && toIndex <= currentStopIndex.value) {
-    currentStopIndex.value += 1
-  }
-
-  markDirty()
+  reorderStops(fromIndex, toIndex)
 }
 
-function formatSavedTime(iso: string) {
-  try {
-    return new Date(iso).toLocaleString()
-  } catch {
-    return iso
-  }
-}
-
-defineExpose({
-  addVenueStop,
-  activeCrawl,
-  hasActiveCrawl: computed(() => !!activeCrawl.value),
-})
-
-onMounted(async () => {
-  await initializeAuth()
-  if (isLoggedIn.value) await loadCrawls()
-})
-
-watch(isLoggedIn, async (loggedIn) => {
-  if (loggedIn) await loadCrawls()
-  else {
-    crawls.value = []
-    startFresh()
-  }
+onMounted(() => {
+  void initialize()
 })
 </script>

--- a/components/map/PubCrawlBuilder.vue
+++ b/components/map/PubCrawlBuilder.vue
@@ -434,6 +434,10 @@ function venueLocationLabel(venue: VenueSearchHit) {
   return [venue.town, venue.county].filter((part) => String(part || '').trim()).join(', ')
 }
 
+function stopLocationLabel(stop: { town?: string | null; county?: string | null }) {
+  return [stop.town, stop.county].filter((part) => String(part || '').trim()).join(', ')
+}
+
 function parseCoord(value: string | number | null | undefined) {
   const n = Number(value)
   return Number.isFinite(n) && n !== 0 ? n : null

--- a/components/map/PubCrawlBuilder.vue
+++ b/components/map/PubCrawlBuilder.vue
@@ -121,25 +121,52 @@
         <section class="space-y-2">
           <h3 class="text-sm font-semibold text-gray-900 dark:text-white">Add a pub</h3>
           <p class="text-xs text-gray-500">
-            Click a pub on the map and use “Add to crawl”, or type a name here.
+            Click a pub on the map and use “Add to crawl”, or search by name below.
           </p>
-          <div class="flex gap-2">
+          <div class="relative">
             <UInput
-              v-model="manualName"
-              class="flex-1"
-              placeholder="Type a pub name…"
+              v-model="venueQuery"
+              icon="i-heroicons-magnifying-glass-20-solid"
+              placeholder="Search pubs by name, town, or county…"
               maxlength="200"
-              @keydown.enter.prevent="onAddManual"
+              autocomplete="off"
+              :loading="searchLoading"
+              @keydown.down.prevent="highlightNext"
+              @keydown.up.prevent="highlightPrev"
+              @keydown.enter.prevent="selectHighlighted"
+              @keydown.esc="closeSearch"
             />
-            <UButton
-              color="gray"
-              variant="soft"
-              :disabled="!manualName.trim() || addingStop"
-              :loading="addingStop"
-              label="Add"
-              @click="onAddManual"
-            />
+            <ul
+              v-if="showSearchResults"
+              class="absolute z-20 mt-1 max-h-64 w-full overflow-auto rounded-md border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
+              role="listbox"
+            >
+              <li v-if="searchLoading" class="px-3 py-2 text-sm text-gray-500">Searching…</li>
+              <li
+                v-else-if="!searchResults.length"
+                class="px-3 py-2 text-sm text-gray-500"
+              >
+                No pubs found. Try another name or town.
+              </li>
+              <li
+                v-for="(venue, index) in searchResults"
+                :key="venue.id"
+                role="option"
+                class="cursor-pointer px-3 py-2 text-sm"
+                :class="index === highlightIndex
+                  ? 'bg-amber-50 text-amber-950 dark:bg-amber-950/50 dark:text-amber-50'
+                  : 'text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-gray-800'"
+                @mousedown.prevent="selectVenue(venue)"
+                @mouseenter="highlightIndex = index"
+              >
+                <span class="block font-medium truncate">{{ venue.venuename }}</span>
+                <span class="block text-xs text-gray-500 dark:text-gray-400 truncate">
+                  {{ venueLocationLabel(venue) }}
+                </span>
+              </li>
+            </ul>
           </div>
+          <p v-if="addingStop" class="text-xs text-gray-500">Adding to crawl…</p>
         </section>
 
         <section class="space-y-2">
@@ -212,7 +239,12 @@
                     <p class="mt-1 truncate font-medium text-gray-900 dark:text-white">
                       {{ stop.venueName }}
                     </p>
-                    <p v-if="!stop.venueId" class="text-xs text-gray-500">Added manually</p>
+                    <p v-if="stopLocationLabel(stop)" class="text-xs text-gray-500 truncate">
+                      {{ stopLocationLabel(stop) }}
+                    </p>
+                    <p v-else-if="!stop.venueId" class="text-xs text-amber-700 dark:text-amber-400">
+                      Not linked to a venue listing
+                    </p>
                   </div>
                   <div class="flex shrink-0 flex-col items-end gap-1">
                     <UButton
@@ -324,16 +356,35 @@ const {
   saveMeta,
   saveCrawl,
   deleteCrawl,
-  addManualStop,
+  addVenueStop,
   removeStopLocal,
   setProgress,
   reorderStops,
   initialize,
 } = usePubCrawl()
 
-const manualName = ref('')
+type VenueSearchHit = {
+  id: number
+  venuename: string
+  town: string
+  county: string
+  latitude?: string | null
+  longitude?: string | null
+}
+
+const venueQuery = ref('')
+const searchResults = ref<VenueSearchHit[]>([])
+const searchLoading = ref(false)
+const searchOpen = ref(false)
+const highlightIndex = ref(-1)
 const dragIndex = ref<number | null>(null)
 const dropIndex = ref<number | null>(null)
+let searchTimer: ReturnType<typeof setTimeout> | null = null
+let searchRequestId = 0
+
+const showSearchResults = computed(() =>
+  searchOpen.value && venueQuery.value.trim().length >= 2,
+)
 
 watch(
   activeCrawl,
@@ -342,6 +393,88 @@ watch(
   },
   { immediate: true },
 )
+
+watch(venueQuery, (value) => {
+  if (searchTimer) clearTimeout(searchTimer)
+  const q = value.trim()
+  if (q.length < 2) {
+    searchResults.value = []
+    searchOpen.value = false
+    highlightIndex.value = -1
+    searchLoading.value = false
+    return
+  }
+  searchOpen.value = true
+  searchLoading.value = true
+  searchTimer = setTimeout(() => {
+    void runVenueSearch(q)
+  }, 250)
+})
+
+async function runVenueSearch(q: string) {
+  const requestId = ++searchRequestId
+  try {
+    const results = await $fetch<VenueSearchHit[]>('/api/venues/search', {
+      params: { q, limit: 12 },
+    })
+    if (requestId !== searchRequestId) return
+    searchResults.value = results
+    highlightIndex.value = results.length ? 0 : -1
+  } catch (err) {
+    if (requestId !== searchRequestId) return
+    console.error('Venue search failed:', err)
+    searchResults.value = []
+    highlightIndex.value = -1
+  } finally {
+    if (requestId === searchRequestId) searchLoading.value = false
+  }
+}
+
+function venueLocationLabel(venue: VenueSearchHit) {
+  return [venue.town, venue.county].filter((part) => String(part || '').trim()).join(', ')
+}
+
+function parseCoord(value: string | number | null | undefined) {
+  const n = Number(value)
+  return Number.isFinite(n) && n !== 0 ? n : null
+}
+
+function closeSearch() {
+  searchOpen.value = false
+  highlightIndex.value = -1
+}
+
+function highlightNext() {
+  if (!searchResults.value.length) return
+  searchOpen.value = true
+  highlightIndex.value = (highlightIndex.value + 1) % searchResults.value.length
+}
+
+function highlightPrev() {
+  if (!searchResults.value.length) return
+  searchOpen.value = true
+  highlightIndex.value =
+    highlightIndex.value <= 0 ? searchResults.value.length - 1 : highlightIndex.value - 1
+}
+
+async function selectHighlighted() {
+  if (highlightIndex.value < 0 || !searchResults.value[highlightIndex.value]) return
+  await selectVenue(searchResults.value[highlightIndex.value])
+}
+
+async function selectVenue(venue: VenueSearchHit) {
+  const ok = await addVenueStop({
+    id: venue.id,
+    name: venue.venuename,
+    lat: parseCoord(venue.latitude),
+    lng: parseCoord(venue.longitude),
+  })
+  if (!ok) return
+  venueQuery.value = ''
+  searchResults.value = []
+  searchOpen.value = false
+  highlightIndex.value = -1
+}
 
 async function selectCrawl(id: string) {
   await loadCrawl(id)
@@ -367,13 +500,6 @@ async function onDeleteCrawl(id: string) {
 function onStartFresh() {
   clearActive()
   draftName.value = ''
-}
-
-async function onAddManual() {
-  const name = manualName.value.trim()
-  if (!name) return
-  const ok = await addManualStop(name)
-  if (ok) manualName.value = ''
 }
 
 function onDragStart(index: number, event: DragEvent) {
@@ -405,5 +531,9 @@ function onDrop(toIndex: number) {
 
 onMounted(() => {
   void initialize()
+})
+
+onBeforeUnmount(() => {
+  if (searchTimer) clearTimeout(searchTimer)
 })
 </script>

--- a/composables/usePubCrawl.ts
+++ b/composables/usePubCrawl.ts
@@ -1,0 +1,425 @@
+import { buildCrawlLegs, formatWalkingDistance } from '@/utils/crawl-distance'
+
+export type CrawlStop = {
+  id?: string
+  venueId: number | null
+  venueName: string
+  latitude: number | null
+  longitude: number | null
+  notes?: string | null
+  sortOrder?: number
+}
+
+export type CrawlSummary = {
+  id: string
+  name: string
+  currentStopIndex: number
+  stopCount: number
+  updatedAt: string
+  stops?: CrawlStop[]
+}
+
+const ACTIVE_CRAWL_KEY = 'ukpubs_active_crawl_id'
+
+const crawls = ref<CrawlSummary[]>([])
+const activeCrawl = ref<CrawlSummary | null>(null)
+const stops = ref<CrawlStop[]>([])
+const currentStopIndex = ref(0)
+const draftName = ref('')
+const loadingList = ref(false)
+const saving = ref(false)
+const addingStop = ref(false)
+const deletingId = ref<string | null>(null)
+const errorMessage = ref('')
+const dirty = ref(false)
+const lastSavedAt = ref('')
+const initialized = ref(false)
+
+function rememberActiveCrawlId(id: string | null) {
+  if (!import.meta.client) return
+  try {
+    if (id) localStorage.setItem(ACTIVE_CRAWL_KEY, id)
+    else localStorage.removeItem(ACTIVE_CRAWL_KEY)
+  } catch {
+    /* ignore */
+  }
+}
+
+function readRememberedCrawlId() {
+  if (!import.meta.client) return null
+  try {
+    return localStorage.getItem(ACTIVE_CRAWL_KEY)
+  } catch {
+    return null
+  }
+}
+
+function formatSavedTime(iso: string) {
+  try {
+    return new Date(iso).toLocaleString()
+  } catch {
+    return iso
+  }
+}
+
+export function usePubCrawl() {
+  const { isLoggedIn, initializeAuth } = useAuth()
+
+  const legs = computed(() => buildCrawlLegs(stops.value))
+
+  const totalWalkLabel = computed(() => {
+    const miles = legs.value.reduce((sum, leg) => sum + (leg.miles ?? 0), 0)
+    if (!miles) return ''
+    return `Total ~${formatWalkingDistance(miles).replace(/^~/, '')}`
+  })
+
+  const progressPercent = computed(() => {
+    if (!stops.value.length) return 0
+    return Math.round(((currentStopIndex.value + 1) / stops.value.length) * 100)
+  })
+
+  const hasActiveCrawl = computed(() => !!activeCrawl.value)
+
+  function legLabel(fromIndex: number) {
+    return legs.value[fromIndex]?.label || 'Distance unknown'
+  }
+
+  function markDirty() {
+    dirty.value = true
+  }
+
+  function clearActive() {
+    activeCrawl.value = null
+    stops.value = []
+    currentStopIndex.value = 0
+    draftName.value = ''
+    dirty.value = false
+    lastSavedAt.value = ''
+    rememberActiveCrawlId(null)
+  }
+
+  async function loadCrawls() {
+    if (!isLoggedIn.value) return
+    loadingList.value = true
+    errorMessage.value = ''
+    try {
+      crawls.value = await useAuthFetch<CrawlSummary[]>('/api/crawls')
+    } catch (err: any) {
+      errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not load crawls'
+    } finally {
+      loadingList.value = false
+    }
+  }
+
+  async function loadCrawl(id: string) {
+    errorMessage.value = ''
+    try {
+      const crawl = await useAuthFetch<CrawlSummary & { stops: CrawlStop[] }>(`/api/crawls/${id}`)
+      activeCrawl.value = crawl
+      draftName.value = crawl.name
+      stops.value = (crawl.stops || []).map((s) => ({ ...s }))
+      currentStopIndex.value = crawl.currentStopIndex || 0
+      dirty.value = false
+      lastSavedAt.value = formatSavedTime(crawl.updatedAt)
+      rememberActiveCrawlId(crawl.id)
+      return crawl
+    } catch (err: any) {
+      errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not load crawl'
+      return null
+    }
+  }
+
+  async function ensureActiveCrawl() {
+    if (activeCrawl.value?.id) return activeCrawl.value
+
+    await loadCrawls()
+
+    const remembered = readRememberedCrawlId()
+    if (remembered && crawls.value.some((c) => c.id === remembered)) {
+      return loadCrawl(remembered)
+    }
+
+    if (crawls.value.length === 1) {
+      return loadCrawl(crawls.value[0].id)
+    }
+
+    if (crawls.value.length > 1) {
+      // Most recently updated
+      return loadCrawl(crawls.value[0].id)
+    }
+
+    errorMessage.value = 'Create a pub crawl first, then add pubs to it.'
+    return null
+  }
+
+  async function createCrawl(nameInput?: string) {
+    const name = (nameInput ?? draftName.value).trim()
+    if (!name) return null
+    saving.value = true
+    errorMessage.value = ''
+    try {
+      const crawl = await useAuthFetch<CrawlSummary>('/api/crawls', {
+        method: 'POST',
+        body: { name },
+      })
+      activeCrawl.value = crawl
+      draftName.value = crawl.name
+      stops.value = []
+      currentStopIndex.value = 0
+      dirty.value = false
+      lastSavedAt.value = 'just now'
+      rememberActiveCrawlId(crawl.id)
+      await loadCrawls()
+      return crawl
+    } catch (err: any) {
+      errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not create crawl'
+      return null
+    } finally {
+      saving.value = false
+    }
+  }
+
+  async function saveMeta() {
+    if (!activeCrawl.value) return null
+    const name = draftName.value.trim()
+    if (!name) return null
+    saving.value = true
+    errorMessage.value = ''
+    try {
+      const crawl = await useAuthFetch<CrawlSummary>(`/api/crawls/${activeCrawl.value.id}`, {
+        method: 'PUT',
+        body: { name },
+      })
+      activeCrawl.value = { ...activeCrawl.value, name: crawl.name }
+      rememberActiveCrawlId(crawl.id)
+      await loadCrawls()
+      return crawl
+    } catch (err: any) {
+      errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not rename crawl'
+      return null
+    } finally {
+      saving.value = false
+    }
+  }
+
+  async function saveCrawl() {
+    if (!activeCrawl.value) return null
+    saving.value = true
+    errorMessage.value = ''
+    try {
+      const crawl = await useAuthFetch<CrawlSummary & { stops: CrawlStop[] }>(
+        `/api/crawls/${activeCrawl.value.id}/stops`,
+        {
+          method: 'PUT',
+          body: {
+            name: draftName.value.trim() || activeCrawl.value.name,
+            currentStopIndex: currentStopIndex.value,
+            stops: stops.value.map((s) => ({
+              venueId: s.venueId,
+              venueName: s.venueName,
+              latitude: s.latitude,
+              longitude: s.longitude,
+              notes: s.notes ?? null,
+            })),
+          },
+        },
+      )
+      activeCrawl.value = crawl
+      draftName.value = crawl.name
+      stops.value = (crawl.stops || []).map((s) => ({ ...s }))
+      currentStopIndex.value = crawl.currentStopIndex || 0
+      dirty.value = false
+      lastSavedAt.value = 'just now'
+      rememberActiveCrawlId(crawl.id)
+      await loadCrawls()
+      return crawl
+    } catch (err: any) {
+      errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not save crawl'
+      return null
+    } finally {
+      saving.value = false
+    }
+  }
+
+  async function deleteCrawl(id: string) {
+    deletingId.value = id
+    errorMessage.value = ''
+    try {
+      await useAuthFetch(`/api/crawls/${id}`, { method: 'DELETE' })
+      if (activeCrawl.value?.id === id) clearActive()
+      await loadCrawls()
+      return true
+    } catch (err: any) {
+      errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not delete crawl'
+      return false
+    } finally {
+      deletingId.value = null
+    }
+  }
+
+  async function addManualStop(nameInput: string) {
+    const name = nameInput.trim()
+    if (!name) return false
+    const crawl = await ensureActiveCrawl()
+    if (!crawl) return false
+
+    addingStop.value = true
+    errorMessage.value = ''
+    try {
+      const created = await useAuthFetch<CrawlStop>(`/api/crawls/${crawl.id}/stops`, {
+        method: 'POST',
+        body: { venueName: name },
+      })
+      stops.value = [...stops.value, created]
+      dirty.value = false
+      lastSavedAt.value = 'just now'
+      await loadCrawls()
+      if (activeCrawl.value) {
+        activeCrawl.value = {
+          ...activeCrawl.value,
+          stopCount: stops.value.length,
+          stops: stops.value,
+        }
+      }
+      return true
+    } catch (err: any) {
+      errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not add stop'
+      return false
+    } finally {
+      addingStop.value = false
+    }
+  }
+
+  /** Add a map venue and persist immediately. */
+  async function addVenueStop(venue: {
+    id: number
+    name: string
+    lat: number | null
+    lng: number | null
+  }) {
+    const crawl = await ensureActiveCrawl()
+    if (!crawl) return false
+
+    if (venue.id && stops.value.some((s) => s.venueId === venue.id)) {
+      errorMessage.value = 'That pub is already on this crawl.'
+      return false
+    }
+
+    addingStop.value = true
+    errorMessage.value = ''
+    try {
+      const created = await useAuthFetch<CrawlStop>(`/api/crawls/${crawl.id}/stops`, {
+        method: 'POST',
+        body: {
+          venueId: venue.id || null,
+          venueName: venue.name,
+          latitude: venue.lat,
+          longitude: venue.lng,
+        },
+      })
+      stops.value = [...stops.value, created]
+      dirty.value = false
+      lastSavedAt.value = 'just now'
+      await loadCrawls()
+      if (activeCrawl.value) {
+        activeCrawl.value = {
+          ...activeCrawl.value,
+          stopCount: stops.value.length,
+          stops: stops.value,
+        }
+      }
+      return true
+    } catch (err: any) {
+      errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not add pub to crawl'
+      return false
+    } finally {
+      addingStop.value = false
+    }
+  }
+
+  function removeStopLocal(index: number) {
+    stops.value.splice(index, 1)
+    if (currentStopIndex.value >= stops.value.length) {
+      currentStopIndex.value = Math.max(0, stops.value.length - 1)
+    }
+    markDirty()
+  }
+
+  function setProgress(index: number) {
+    if (index < 0 || index >= stops.value.length) return
+    currentStopIndex.value = index
+    markDirty()
+  }
+
+  function reorderStops(fromIndex: number, toIndex: number) {
+    if (fromIndex === toIndex) return
+    const next = stops.value.slice()
+    const [moved] = next.splice(fromIndex, 1)
+    next.splice(toIndex, 0, moved)
+    stops.value = next
+
+    if (currentStopIndex.value === fromIndex) {
+      currentStopIndex.value = toIndex
+    } else if (fromIndex < currentStopIndex.value && toIndex >= currentStopIndex.value) {
+      currentStopIndex.value -= 1
+    } else if (fromIndex > currentStopIndex.value && toIndex <= currentStopIndex.value) {
+      currentStopIndex.value += 1
+    }
+    markDirty()
+  }
+
+  async function initialize() {
+    await initializeAuth()
+    if (!isLoggedIn.value) {
+      crawls.value = []
+      clearActive()
+      initialized.value = true
+      return
+    }
+    await loadCrawls()
+    if (!activeCrawl.value) {
+      const remembered = readRememberedCrawlId()
+      if (remembered && crawls.value.some((c) => c.id === remembered)) {
+        await loadCrawl(remembered)
+      } else if (crawls.value.length === 1) {
+        await loadCrawl(crawls.value[0].id)
+      }
+    }
+    initialized.value = true
+  }
+
+  return {
+    crawls,
+    activeCrawl,
+    stops,
+    currentStopIndex,
+    draftName,
+    loadingList,
+    saving,
+    addingStop,
+    deletingId,
+    errorMessage,
+    dirty,
+    lastSavedAt,
+    initialized,
+    legs,
+    totalWalkLabel,
+    progressPercent,
+    hasActiveCrawl,
+    legLabel,
+    clearActive,
+    loadCrawls,
+    loadCrawl,
+    ensureActiveCrawl,
+    createCrawl,
+    saveMeta,
+    saveCrawl,
+    deleteCrawl,
+    addManualStop,
+    addVenueStop,
+    removeStopLocal,
+    setProgress,
+    reorderStops,
+    initialize,
+  }
+}

--- a/composables/usePubCrawl.ts
+++ b/composables/usePubCrawl.ts
@@ -21,20 +21,6 @@ export type CrawlSummary = {
 
 const ACTIVE_CRAWL_KEY = 'ukpubs_active_crawl_id'
 
-const crawls = ref<CrawlSummary[]>([])
-const activeCrawl = ref<CrawlSummary | null>(null)
-const stops = ref<CrawlStop[]>([])
-const currentStopIndex = ref(0)
-const draftName = ref('')
-const loadingList = ref(false)
-const saving = ref(false)
-const addingStop = ref(false)
-const deletingId = ref<string | null>(null)
-const errorMessage = ref('')
-const dirty = ref(false)
-const lastSavedAt = ref('')
-const initialized = ref(false)
-
 function rememberActiveCrawlId(id: string | null) {
   if (!import.meta.client) return
   try {
@@ -64,6 +50,20 @@ function formatSavedTime(iso: string) {
 
 export function usePubCrawl() {
   const { isLoggedIn, initializeAuth } = useAuth()
+
+  const crawls = useState<CrawlSummary[]>('ukpubs-crawls', () => [])
+  const activeCrawl = useState<CrawlSummary | null>('ukpubs-active-crawl', () => null)
+  const stops = useState<CrawlStop[]>('ukpubs-crawl-stops', () => [])
+  const currentStopIndex = useState<number>('ukpubs-crawl-progress', () => 0)
+  const draftName = useState<string>('ukpubs-crawl-draft-name', () => '')
+  const loadingList = useState<boolean>('ukpubs-crawl-loading', () => false)
+  const saving = useState<boolean>('ukpubs-crawl-saving', () => false)
+  const addingStop = useState<boolean>('ukpubs-crawl-adding', () => false)
+  const deletingId = useState<string | null>('ukpubs-crawl-deleting', () => null)
+  const errorMessage = useState<string>('ukpubs-crawl-error', () => '')
+  const dirty = useState<boolean>('ukpubs-crawl-dirty', () => false)
+  const lastSavedAt = useState<string>('ukpubs-crawl-saved-at', () => '')
+  const initialized = useState<boolean>('ukpubs-crawl-initialized', () => false)
 
   const legs = computed(() => buildCrawlLegs(stops.value))
 
@@ -130,7 +130,12 @@ export function usePubCrawl() {
   }
 
   async function ensureActiveCrawl() {
-    if (activeCrawl.value?.id) return activeCrawl.value
+    if (activeCrawl.value?.id) {
+      if (!stops.value.length && (activeCrawl.value.stopCount || 0) > 0) {
+        await loadCrawl(activeCrawl.value.id)
+      }
+      return activeCrawl.value
+    }
 
     await loadCrawls()
 
@@ -139,12 +144,7 @@ export function usePubCrawl() {
       return loadCrawl(remembered)
     }
 
-    if (crawls.value.length === 1) {
-      return loadCrawl(crawls.value[0].id)
-    }
-
-    if (crawls.value.length > 1) {
-      // Most recently updated
+    if (crawls.value.length >= 1) {
       return loadCrawl(crawls.value[0].id)
     }
 
@@ -300,6 +300,10 @@ export function usePubCrawl() {
     const crawl = await ensureActiveCrawl()
     if (!crawl) return false
 
+    if (!stops.value.length && (crawl.stopCount || 0) > 0) {
+      await loadCrawl(crawl.id)
+    }
+
     if (venue.id && stops.value.some((s) => s.venueId === venue.id)) {
       errorMessage.value = 'That pub is already on this crawl.'
       return false
@@ -384,6 +388,8 @@ export function usePubCrawl() {
       } else if (crawls.value.length === 1) {
         await loadCrawl(crawls.value[0].id)
       }
+    } else if (activeCrawl.value.id && !stops.value.length && activeCrawl.value.stopCount) {
+      await loadCrawl(activeCrawl.value.id)
     }
     initialized.value = true
   }

--- a/composables/usePubCrawl.ts
+++ b/composables/usePubCrawl.ts
@@ -4,6 +4,8 @@ export type CrawlStop = {
   id?: string
   venueId: number | null
   venueName: string
+  town?: string | null
+  county?: string | null
   latitude: number | null
   longitude: number | null
   notes?: string | null
@@ -257,37 +259,10 @@ export function usePubCrawl() {
     }
   }
 
-  async function addManualStop(nameInput: string) {
-    const name = nameInput.trim()
-    if (!name) return false
-    const crawl = await ensureActiveCrawl()
-    if (!crawl) return false
-
-    addingStop.value = true
-    errorMessage.value = ''
-    try {
-      const created = await useAuthFetch<CrawlStop>(`/api/crawls/${crawl.id}/stops`, {
-        method: 'POST',
-        body: { venueName: name },
-      })
-      stops.value = [...stops.value, created]
-      dirty.value = false
-      lastSavedAt.value = 'just now'
-      await loadCrawls()
-      if (activeCrawl.value) {
-        activeCrawl.value = {
-          ...activeCrawl.value,
-          stopCount: stops.value.length,
-          stops: stops.value,
-        }
-      }
-      return true
-    } catch (err: any) {
-      errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not add stop'
-      return false
-    } finally {
-      addingStop.value = false
-    }
+  async function addManualStop(_nameInput: string) {
+    // Manual free-text stops are no longer supported — use addVenueStop with a DB venue.
+    errorMessage.value = 'Pick a pub from the search results.'
+    return false
   }
 
   /** Add a map venue and persist immediately. */

--- a/pages/map/index.vue
+++ b/pages/map/index.vue
@@ -78,7 +78,6 @@
     <USlideover v-model="isCrawlBuilderOpen" side="left" :ui="{ width: 'w-screen max-w-md' }">
       <MapPubCrawlBuilder
         v-if="isLoggedIn"
-        ref="crawlBuilderRef"
         @close="isCrawlBuilderOpen = false"
         @crawl-updated="onCrawlUpdated"
       />
@@ -171,6 +170,7 @@
               variant="soft"
               icon="i-heroicons-plus-20-solid"
               :label="addToCrawlLabel"
+              :loading="crawlAddPending"
               @click="addSelectedVenueToCrawl"
             />
           </div>
@@ -200,25 +200,26 @@ const eventStore = useEventStore()
 const mapboxToken = useMapboxToken()
 const config = useRuntimeConfig()
 const { isLoggedIn, initializeAuth } = useAuth()
+const {
+  activeCrawl,
+  addVenueStop,
+  initialize: initializePubCrawl,
+  errorMessage: crawlErrorMessage,
+} = usePubCrawl()
 
 const selectedCity = ref('')
 const cityNames = computed(() => eventStore.cities.map((city) => city.name))
 
 const isCrawlBuilderOpen = ref(false)
-const crawlBuilderRef = ref<{
-  addVenueStop: (venue: { id: number; name: string; lat: number | null; lng: number | null }) => boolean
-  activeCrawl: { value?: { name?: string } | null } | { name?: string } | null
-  hasActiveCrawl?: { value: boolean } | boolean
-} | null>(null)
-const activeCrawlName = ref('')
 const crawlAddMessage = ref('')
+const crawlAddPending = ref(false)
 let crawlAddMessageTimeout: ReturnType<typeof setTimeout> | null = null
 
 const crawlButtonLabel = computed(() =>
-  activeCrawlName.value ? `Pub crawl · ${activeCrawlName.value}` : 'Pub crawl',
+  activeCrawl.value?.name ? `Pub crawl · ${activeCrawl.value.name}` : 'Pub crawl',
 )
 const addToCrawlLabel = computed(() =>
-  activeCrawlName.value ? `Add to ${activeCrawlName.value}` : 'Add to crawl',
+  activeCrawl.value?.name ? `Add to ${activeCrawl.value.name}` : 'Add to crawl',
 )
 
 function openCrawlBuilder() {
@@ -226,59 +227,41 @@ function openCrawlBuilder() {
   crawlAddMessage.value = ''
 }
 
-function onCrawlUpdated(crawl: { name?: string } | null) {
-  activeCrawlName.value = crawl?.name || ''
+function onCrawlUpdated(_crawl: { id: string; name: string } | null) {
+  // activeCrawl is shared via usePubCrawl(); label updates from that ref
 }
 
-function addSelectedVenueToCrawl() {
-  if (!selectedVenue.value) return
+async function addSelectedVenueToCrawl() {
+  if (!selectedVenue.value || crawlAddPending.value) return
   crawlAddMessage.value = ''
+  crawlAddPending.value = true
 
-  const tryAdd = (attemptsLeft: number) => {
-    const builder = crawlBuilderRef.value
-    if (!builder?.addVenueStop) {
-      if (attemptsLeft > 0) {
-        requestAnimationFrame(() => tryAdd(attemptsLeft - 1))
-      } else {
-        crawlAddMessage.value = 'Open the pub crawl builder and create or load a crawl first.'
-      }
-      return
-    }
-
-    const active = unwrapRef(builder.activeCrawl)
-    if (!active) {
-      crawlAddMessage.value = 'Create or open a crawl in the builder, then add this pub.'
-      return
-    }
-
-    const ok = builder.addVenueStop({
-      id: selectedVenue.value!.id,
-      name: selectedVenue.value!.name,
-      lat: selectedVenue.value!.lat,
-      lng: selectedVenue.value!.lng,
+  try {
+    await initializePubCrawl()
+    const ok = await addVenueStop({
+      id: selectedVenue.value.id,
+      name: selectedVenue.value.name,
+      lat: selectedVenue.value.lat,
+      lng: selectedVenue.value.lng,
     })
 
     if (ok) {
-      crawlAddMessage.value = `Added ${selectedVenue.value!.name} to your crawl. Remember to save.`
+      isCrawlBuilderOpen.value = true
+      crawlAddMessage.value = `Added ${selectedVenue.value.name} to ${activeCrawl.value?.name || 'your crawl'}.`
       if (crawlAddMessageTimeout) clearTimeout(crawlAddMessageTimeout)
       crawlAddMessageTimeout = setTimeout(() => {
         crawlAddMessage.value = ''
       }, 4000)
     } else {
-      // Builder sets its own error (e.g. duplicate); surface a short cue here too
-      crawlAddMessage.value = 'Could not add this pub — check the crawl builder panel.'
+      isCrawlBuilderOpen.value = true
+      crawlAddMessage.value = crawlErrorMessage.value || 'Could not add this pub — create or open a crawl first.'
     }
+  } catch (err: any) {
+    isCrawlBuilderOpen.value = true
+    crawlAddMessage.value = err?.data?.statusMessage || err?.message || 'Could not add this pub to the crawl.'
+  } finally {
+    crawlAddPending.value = false
   }
-
-  if (!isCrawlBuilderOpen.value) isCrawlBuilderOpen.value = true
-  nextTick(() => tryAdd(12))
-}
-
-function unwrapRef<T>(value: { value?: T } | T | null | undefined): T | null | undefined {
-  if (value && typeof value === 'object' && 'value' in (value as object)) {
-    return (value as { value: T }).value
-  }
-  return value as T | null | undefined
 }
 
 const isOpenRight = reactive({
@@ -347,6 +330,7 @@ onMounted(async () => {
   updateDesktopViewport()
   desktopMediaQuery.addEventListener('change', updateDesktopViewport)
   void initializeAuth()
+  void initializePubCrawl()
   void eventStore.fetchCities()
   void loadFilterData()
   await createMap()

--- a/server/api/crawls/[id].ts
+++ b/server/api/crawls/[id].ts
@@ -39,14 +39,12 @@ export default defineEventHandler(async (event) => {
       data.currentStopIndex = Math.min(index, maxIndex)
     }
 
-    const crawl = await prisma.ukpubsCrawl.update({
+    await prisma.ukpubsCrawl.update({
       where: { id: crawlId },
       data,
-      include: {
-        stops: { orderBy: { sortOrder: 'asc' } },
-      },
     })
 
+    const crawl = await getCrawlForUser(crawlId, user.id)
     return serializeCrawl(crawl)
   }
 

--- a/server/api/crawls/[id]/stops.ts
+++ b/server/api/crawls/[id]/stops.ts
@@ -5,6 +5,7 @@ import {
   parseOptionalCoord,
   serializeCrawl,
   serializeStop,
+  stopInclude,
 } from '../../../utils/crawls'
 
 type IncomingStop = {
@@ -30,6 +31,13 @@ export default defineEventHandler(async (event) => {
     const body = await readBody(event)
     const stop = await resolveStopInput(body)
 
+    if (!stop.venueId) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: 'Select a pub from search results (venueId is required)',
+      })
+    }
+
     const created = await prisma.ukpubsCrawlStop.create({
       data: {
         crawlId,
@@ -40,6 +48,7 @@ export default defineEventHandler(async (event) => {
         notes: stop.notes,
         sortOrder: crawl.stops.length,
       },
+      include: stopInclude,
     })
 
     return serializeStop(created)
@@ -55,7 +64,7 @@ export default defineEventHandler(async (event) => {
 
     const resolved = await Promise.all(stopsInput.map((item) => resolveStopInput(item)))
 
-    const crawl = await prisma.$transaction(async (tx) => {
+    await prisma.$transaction(async (tx) => {
       await tx.ukpubsCrawlStop.deleteMany({ where: { crawlId } })
 
       if (resolved.length) {
@@ -77,18 +86,16 @@ export default defineEventHandler(async (event) => {
         ? Math.max(0, Math.min(Number(body.currentStopIndex), Math.max(0, resolved.length - 1)))
         : 0
 
-      return tx.ukpubsCrawl.update({
+      await tx.ukpubsCrawl.update({
         where: { id: crawlId },
         data: {
           ...(body?.name != null ? { name: String(body.name).trim() || undefined } : {}),
           currentStopIndex: resolved.length === 0 ? 0 : currentStopIndex,
         },
-        include: {
-          stops: { orderBy: { sortOrder: 'asc' } },
-        },
       })
     })
 
+    const crawl = await getCrawlForUser(crawlId, user.id)
     return serializeCrawl(crawl)
   }
 

--- a/server/api/crawls/index.ts
+++ b/server/api/crawls/index.ts
@@ -10,7 +10,19 @@ export default defineEventHandler(async (event) => {
     const crawls = await prisma.ukpubsCrawl.findMany({
       where: { userId: user.id },
       include: {
-        stops: { orderBy: { sortOrder: 'asc' } },
+        stops: {
+          orderBy: { sortOrder: 'asc' },
+          include: {
+            venue: {
+              select: {
+                id: true,
+                venuename: true,
+                town: true,
+                county: true,
+              },
+            },
+          },
+        },
       },
       orderBy: { updatedAt: 'desc' },
     })

--- a/server/api/venues/search.get.ts
+++ b/server/api/venues/search.get.ts
@@ -1,27 +1,43 @@
 import { prisma } from '../../utils/prisma'
-;
 
 export default defineEventHandler(async (event) => {
-  setHeader(event, 'Cache-Control', 'public, max-age=300, s-maxage=3600, stale-while-revalidate=86400');
+  setHeader(event, 'Cache-Control', 'public, max-age=300, s-maxage=3600, stale-while-revalidate=86400')
 
-  const query = getQuery(event);
-  const q = query.q;
+  const query = getQuery(event)
+  const q = String(query.q || '').trim()
+  const limitRaw = Number.parseInt(String(query.limit || '20'), 10)
+  const limit = Number.isFinite(limitRaw) ? Math.min(Math.max(limitRaw, 1), 50) : 20
 
-  // Find venues matching the query, ordered by their closeness
+  if (q.length < 2) {
+    return []
+  }
+
   const results = await prisma.venue.findMany({
     where: {
-      venuename: {
-        contains: q, // Assuming you want to search for venues whose name contains the query
-        mode: 'insensitive'
-      }
+      OR: [
+        { venuename: { contains: q, mode: 'insensitive' } },
+        { town: { contains: q, mode: 'insensitive' } },
+        { county: { contains: q, mode: 'insensitive' } },
+      ],
     },
     select: {
       id: true,
       venuename: true,
-      town: true
+      town: true,
+      county: true,
+      latitude: true,
+      longitude: true,
     },
-    take: 100
-  });
+    orderBy: { venuename: 'asc' },
+    take: limit,
+  })
 
-  return results;
-});
+  return results.map((venue) => ({
+    id: venue.id,
+    venuename: venue.venuename,
+    town: venue.town,
+    county: venue.county,
+    latitude: venue.latitude,
+    longitude: venue.longitude,
+  }))
+})

--- a/server/utils/crawls.ts
+++ b/server/utils/crawls.ts
@@ -1,11 +1,17 @@
-import type { UkpubsCrawl, UkpubsCrawlStop } from '@prisma/client'
+import type { UkpubsCrawl, UkpubsCrawlStop, Venue } from '@prisma/client'
 import { prisma } from './prisma'
+
+type StopWithVenue = UkpubsCrawlStop & {
+  venue?: Pick<Venue, 'id' | 'venuename' | 'town' | 'county'> | null
+}
 
 export type CrawlStopDto = {
   id: string
   crawlId: string
   venueId: number | null
   venueName: string
+  town: string | null
+  county: string | null
   latitude: number | null
   longitude: number | null
   sortOrder: number
@@ -24,12 +30,16 @@ export type CrawlDto = {
   stopCount: number
 }
 
-export function serializeStop(stop: UkpubsCrawlStop): CrawlStopDto {
+export function serializeStop(stop: StopWithVenue): CrawlStopDto {
+  const town = stop.venue?.town?.trim() || null
+  const county = stop.venue?.county?.trim() || null
   return {
     id: stop.id,
     crawlId: stop.crawlId,
     venueId: stop.venueId,
     venueName: stop.venueName,
+    town,
+    county,
     latitude: stop.latitude,
     longitude: stop.longitude,
     sortOrder: stop.sortOrder,
@@ -39,7 +49,7 @@ export function serializeStop(stop: UkpubsCrawlStop): CrawlStopDto {
 }
 
 export function serializeCrawl(
-  crawl: UkpubsCrawl & { stops?: UkpubsCrawlStop[] },
+  crawl: UkpubsCrawl & { stops?: StopWithVenue[] },
 ): CrawlDto {
   const stops = (crawl.stops || [])
     .slice()
@@ -58,11 +68,25 @@ export function serializeCrawl(
   }
 }
 
+const stopInclude = {
+  venue: {
+    select: {
+      id: true,
+      venuename: true,
+      town: true,
+      county: true,
+    },
+  },
+} as const
+
 export async function getCrawlForUser(crawlId: string, userId: string) {
   const crawl = await prisma.ukpubsCrawl.findFirst({
     where: { id: crawlId, userId },
     include: {
-      stops: { orderBy: { sortOrder: 'asc' } },
+      stops: {
+        orderBy: { sortOrder: 'asc' },
+        include: stopInclude,
+      },
     },
   })
   if (!crawl) {
@@ -77,3 +101,5 @@ export function parseOptionalCoord(value: unknown): number | null {
   if (!Number.isFinite(n) || n === 0) return null
   return n
 }
+
+export { stopInclude }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
1. Adding a pub from the map modal did not persist stops.
2. Typing a pub name allowed any free-text string instead of picking a real venue from the database.

## Fix
- Shared `usePubCrawl` state + immediate `POST /api/crawls/:id/stops` when adding pubs
- Slideover search now **autocompletes from `/api/venues/search`**, showing **name, town, and county**
- Selecting a result adds that real venue (with coords for walking distances)
- Free-text-only stops are no longer accepted from the builder

## Test
1. Open Pub crawl → create/select a crawl
2. In the search box, type a pub name (e.g. “Black”) — results show town & county
3. Click a result → it appears on the route and in `ukpubs_crawl_stops` with a `venue_id`
4. From the map modal, **Add to crawl** also persists immediately
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f115d295-b0d1-4947-b408-4e43bc3859e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f115d295-b0d1-4947-b408-4e43bc3859e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

