### PR TITLE
Multi crawl lists, map routes, and 50m auto check-in

### DIFF
--- a/components/map/PubCrawlBuilder.vue
+++ b/components/map/PubCrawlBuilder.vue
@@ -375,7 +375,6 @@ const {
   deleteCrawl,
   addVenueStop,
   removeStopLocal,
-  setProgress,
   setProgressAndSave,
   reorderStops,
   initialize,

--- a/components/map/PubCrawlBuilder.vue
+++ b/components/map/PubCrawlBuilder.vue
@@ -4,7 +4,7 @@
       <div>
         <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Pub crawl builder</h2>
         <p class="mt-0.5 text-sm text-gray-500 dark:text-gray-400">
-          Pick pubs on the map, reorder the route, and track your progress.
+          Keep multiple crawl lists, plot the route on the map, and auto check-in within 50m.
         </p>
       </div>
       <UButton
@@ -296,6 +296,9 @@
         </section>
 
         <section class="space-y-3 border-t border-gray-200 pt-3 dark:border-gray-800">
+          <p class="text-xs text-gray-500">
+            On the map: dotted walking line + distance labels. Allow location to auto-mark arrival within 50m.
+          </p>
           <div v-if="stops.length" class="space-y-1">
             <div class="flex justify-between text-xs text-gray-500">
               <span>Progress</span>

--- a/components/map/PubCrawlBuilder.vue
+++ b/components/map/PubCrawlBuilder.vue
@@ -28,17 +28,33 @@
 
       <section class="space-y-2">
         <div class="flex items-center justify-between gap-2">
-          <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">Your crawls</h3>
-          <UButton
-            size="xs"
-            color="gray"
-            variant="ghost"
-            icon="i-heroicons-arrow-path-20-solid"
-            :loading="loadingList"
-            aria-label="Refresh crawls"
-            @click="loadCrawls"
-          />
+          <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">
+            Your crawl lists
+            <span v-if="crawls.length" class="font-normal normal-case tracking-normal">({{ crawls.length }})</span>
+          </h3>
+          <div class="flex items-center gap-1">
+            <UButton
+              size="xs"
+              color="amber"
+              variant="soft"
+              icon="i-heroicons-plus-20-solid"
+              label="New list"
+              @click="onStartFresh"
+            />
+            <UButton
+              size="xs"
+              color="gray"
+              variant="ghost"
+              icon="i-heroicons-arrow-path-20-solid"
+              :loading="loadingList"
+              aria-label="Refresh crawls"
+              @click="loadCrawls"
+            />
+          </div>
         </div>
+        <p class="text-xs text-gray-500">
+          You can keep as many crawl lists as you like. Tap one to open it on the map.
+        </p>
 
         <div v-if="loadingList && !crawls.length" class="text-sm text-gray-500">Loading…</div>
         <ul v-else-if="crawls.length" class="space-y-1">
@@ -61,6 +77,7 @@
                 <template v-if="crawl.stopCount">
                   · at #{{ Math.min(crawl.currentStopIndex + 1, crawl.stopCount) }}
                 </template>
+                <template v-if="crawl.id === activeCrawl?.id"> · active</template>
               </span>
             </button>
             <UButton
@@ -79,7 +96,7 @@
 
       <section class="space-y-2 rounded-md border border-gray-200 p-3 dark:border-gray-800">
         <label class="block text-sm font-medium text-gray-900 dark:text-white">
-          {{ activeCrawl ? 'Crawl name' : 'New crawl name' }}
+          {{ creatingNewList || !activeCrawl ? 'New crawl list name' : 'Rename active crawl' }}
         </label>
         <div class="flex gap-2">
           <UInput
@@ -87,10 +104,10 @@
             class="flex-1"
             placeholder="e.g. Friday night in Liverpool"
             maxlength="120"
-            @keydown.enter.prevent="activeCrawl ? onSaveMeta() : onCreateCrawl()"
+            @keydown.enter.prevent="creatingNewList || !activeCrawl ? onCreateCrawl() : onSaveMeta()"
           />
           <UButton
-            v-if="!activeCrawl"
+            v-if="creatingNewList || !activeCrawl"
             color="amber"
             :loading="saving"
             :disabled="!draftName.trim()"
@@ -108,12 +125,12 @@
           />
         </div>
         <UButton
-          v-if="activeCrawl"
+          v-if="creatingNewList && crawls.length"
           size="xs"
           color="gray"
           variant="link"
-          label="Start a new crawl"
-          @click="onStartFresh"
+          label="Cancel — back to lists"
+          @click="cancelNewList"
         />
       </section>
 
@@ -253,7 +270,7 @@
                       variant="ghost"
                       label="Here"
                       :disabled="index === currentStopIndex"
-                      @click="setProgress(index)"
+                      @click="setProgressAndSave(index)"
                     />
                     <UButton
                       size="xs"
@@ -297,7 +314,7 @@
                 variant="soft"
                 label="Previous"
                 :disabled="currentStopIndex <= 0 || saving"
-                @click="setProgress(currentStopIndex - 1)"
+                @click="setProgressAndSave(currentStopIndex - 1)"
               />
               <UButton
                 size="xs"
@@ -305,7 +322,7 @@
                 variant="soft"
                 label="Next pub"
                 :disabled="currentStopIndex >= stops.length - 1 || saving"
-                @click="setProgress(currentStopIndex + 1)"
+                @click="setProgressAndSave(currentStopIndex + 1)"
               />
             </div>
           </div>
@@ -359,6 +376,7 @@ const {
   addVenueStop,
   removeStopLocal,
   setProgress,
+  setProgressAndSave,
   reorderStops,
   initialize,
 } = usePubCrawl()
@@ -377,6 +395,7 @@ const searchResults = ref<VenueSearchHit[]>([])
 const searchLoading = ref(false)
 const searchOpen = ref(false)
 const highlightIndex = ref(-1)
+const creatingNewList = ref(false)
 const dragIndex = ref<number | null>(null)
 const dropIndex = ref<number | null>(null)
 let searchTimer: ReturnType<typeof setTimeout> | null = null
@@ -481,11 +500,13 @@ async function selectVenue(venue: VenueSearchHit) {
 }
 
 async function selectCrawl(id: string) {
+  creatingNewList.value = false
   await loadCrawl(id)
 }
 
 async function onCreateCrawl() {
-  await createCrawl()
+  const crawl = await createCrawl()
+  if (crawl) creatingNewList.value = false
 }
 
 async function onSaveMeta() {
@@ -502,8 +523,16 @@ async function onDeleteCrawl(id: string) {
 }
 
 function onStartFresh() {
+  creatingNewList.value = true
   clearActive()
   draftName.value = ''
+}
+
+async function cancelNewList() {
+  creatingNewList.value = false
+  if (crawls.value.length) {
+    await loadCrawl(crawls.value[0].id)
+  }
 }
 
 function onDragStart(index: number, event: DragEvent) {

--- a/composables/usePubCrawl.ts
+++ b/composables/usePubCrawl.ts
@@ -390,7 +390,8 @@ export function usePubCrawl() {
       const remembered = readRememberedCrawlId()
       if (remembered && crawls.value.some((c) => c.id === remembered)) {
         await loadCrawl(remembered)
-      } else if (crawls.value.length === 1) {
+      } else if (crawls.value.length >= 1) {
+        // Always open the most recently updated list so the map has an active route
         await loadCrawl(crawls.value[0].id)
       }
     } else if (activeCrawl.value.id && !stops.value.length && activeCrawl.value.stopCount) {

--- a/composables/usePubCrawl.ts
+++ b/composables/usePubCrawl.ts
@@ -330,6 +330,36 @@ export function usePubCrawl() {
     markDirty()
   }
 
+  /** Persist progress immediately (manual Next / auto check-in). */
+  async function setProgressAndSave(index: number, options?: { fromArrival?: boolean }) {
+    if (!activeCrawl.value) return false
+    if (index < 0 || index >= stops.value.length) return false
+
+    // Only move forward on auto-arrival; allow manual jumps either way
+    if (options?.fromArrival && index <= currentStopIndex.value) return false
+
+    currentStopIndex.value = index
+    errorMessage.value = ''
+    try {
+      const crawl = await useAuthFetch<CrawlSummary>(`/api/crawls/${activeCrawl.value.id}`, {
+        method: 'PUT',
+        body: { currentStopIndex: index },
+      })
+      activeCrawl.value = {
+        ...activeCrawl.value,
+        currentStopIndex: crawl.currentStopIndex,
+      }
+      dirty.value = false
+      lastSavedAt.value = 'just now'
+      await loadCrawls()
+      return true
+    } catch (err: any) {
+      errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not update progress'
+      markDirty()
+      return false
+    }
+  }
+
   function reorderStops(fromIndex: number, toIndex: number) {
     if (fromIndex === toIndex) return
     const next = stops.value.slice()
@@ -400,6 +430,7 @@ export function usePubCrawl() {
     addVenueStop,
     removeStopLocal,
     setProgress,
+    setProgressAndSave,
     reorderStops,
     initialize,
   }

--- a/pages/map/index.vue
+++ b/pages/map/index.vue
@@ -301,14 +301,6 @@ function onCrawlUpdated(_crawl: { id: string; name: string } | null) {
   updateCrawlRouteOnMap()
 }
 
-async function onCrawlSelectChange(value: string | number | boolean) {
-  const id = String(value || '')
-  if (!id || id === activeCrawl.value?.id) return
-  await loadCrawl(id)
-  updateCrawlRouteOnMap()
-  fitMapToCrawlStops()
-}
-
 async function addSelectedVenueToCrawl() {
   if (!selectedVenue.value || crawlAddPending.value) return
   crawlAddMessage.value = ''

--- a/pages/map/index.vue
+++ b/pages/map/index.vue
@@ -3,15 +3,25 @@
     <div class="flex justify-between w-full text-xl items-center container mx-auto py-3 gap-3 flex-wrap">
       <span>{{ venueName }}</span>
       <div class="flex items-center gap-2 flex-wrap">
-        <UButton
-          v-if="isLoggedIn"
-          size="sm"
-          color="amber"
-          variant="soft"
-          icon="i-heroicons-map-20-solid"
-          :label="crawlPanelLabel"
-          @click="openCrawlBuilder"
-        />
+        <template v-if="isLoggedIn">
+          <USelect
+            v-if="crawlSelectOptions.length"
+            v-model="selectedCrawlId"
+            size="sm"
+            color="white"
+            class="min-w-[12rem]"
+            :options="crawlSelectOptions"
+            placeholder="Select crawl list…"
+          />
+          <UButton
+            size="sm"
+            color="amber"
+            variant="soft"
+            icon="i-heroicons-map-20-solid"
+            :label="crawlButtonLabel"
+            @click="openCrawlBuilder"
+          />
+        </template>
         <USelect
           class="content-center"
           icon="i-heroicons-map-pin-20-solid"
@@ -23,6 +33,12 @@
           @change="searchCity(selectedCity)"
         />
       </div>
+    </div>
+    <div
+      v-if="arrivalMessage"
+      class="bg-emerald-50 border-b border-emerald-200 px-4 py-2 text-center text-sm text-emerald-900"
+    >
+      {{ arrivalMessage }}
     </div>
     <div class="bg-gray-100 border-t">
       <venue-namesList class="h-full" :venuenames="venueStore.names" @venue-name="venueNameSelected" />
@@ -184,10 +200,14 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, onMounted, computed } from 'vue'
+import { ref, reactive, onMounted, computed, watch } from 'vue'
 import { useVenueStore } from '@/store/venue.js'
 import { useEventStore } from '@/store/event.js'
 import { resolveVenueDisplayPhotoUrl } from '@/utils/format-venue'
+import {
+  CRAWL_ARRIVAL_RADIUS_METERS,
+  findNearestStopIndex,
+} from '@/utils/crawl-distance'
 
 useSiteSeo({
   title: 'Map of UK pubs and venues',
@@ -201,8 +221,14 @@ const mapboxToken = useMapboxToken()
 const config = useRuntimeConfig()
 const { isLoggedIn, initializeAuth } = useAuth()
 const {
+  crawls,
   activeCrawl,
+  stops,
+  legs,
+  currentStopIndex,
   addVenueStop,
+  loadCrawl,
+  setProgressAndSave,
   initialize: initializePubCrawl,
   errorMessage: crawlErrorMessage,
 } = usePubCrawl()
@@ -213,14 +239,57 @@ const cityNames = computed(() => eventStore.cities.map((city) => city.name))
 const isCrawlBuilderOpen = ref(false)
 const crawlAddMessage = ref('')
 const crawlAddPending = ref(false)
+const arrivalMessage = ref('')
+const selectedCrawlId = ref('')
 let crawlAddMessageTimeout: ReturnType<typeof setTimeout> | null = null
+let arrivalMessageTimeout: ReturnType<typeof setTimeout> | null = null
+let geoWatchId: number | null = null
+let lastArrivalIndex: number | null = null
 
-const crawlButtonLabel = computed(() =>
-  activeCrawl.value?.name ? `Pub crawl · ${activeCrawl.value.name}` : 'Pub crawl',
+const crawlSelectOptions = computed(() =>
+  crawls.value.map((crawl) => ({
+    label: `${crawl.name} (${crawl.stopCount})`,
+    value: crawl.id,
+  })),
 )
+
+const crawlButtonLabel = computed(() => {
+  if (!activeCrawl.value?.name) return 'Manage crawls'
+  return crawls.value.length > 1
+    ? `Manage · ${crawls.value.length} lists`
+    : `Manage · ${activeCrawl.value.name}`
+})
 const addToCrawlLabel = computed(() =>
   activeCrawl.value?.name ? `Add to ${activeCrawl.value.name}` : 'Add to crawl',
 )
+
+watch(
+  () => activeCrawl.value?.id,
+  (id) => {
+    selectedCrawlId.value = id || ''
+  },
+  { immediate: true },
+)
+
+watch(selectedCrawlId, async (id, prev) => {
+  if (!id || id === activeCrawl.value?.id || id === prev) return
+  await loadCrawl(id)
+  updateCrawlRouteOnMap()
+  fitMapToCrawlStops()
+})
+
+watch(
+  [stops, currentStopIndex, () => activeCrawl.value?.id],
+  () => {
+    updateCrawlRouteOnMap()
+  },
+  { deep: true },
+)
+
+watch(isLoggedIn, (loggedIn) => {
+  if (loggedIn) startCrawlGeolocation()
+  else stopCrawlGeolocation()
+})
 
 function openCrawlBuilder() {
   isCrawlBuilderOpen.value = true
@@ -228,7 +297,16 @@ function openCrawlBuilder() {
 }
 
 function onCrawlUpdated(_crawl: { id: string; name: string } | null) {
-  // activeCrawl is shared via usePubCrawl(); label updates from that ref
+  selectedCrawlId.value = activeCrawl.value?.id || ''
+  updateCrawlRouteOnMap()
+}
+
+async function onCrawlSelectChange(value: string | number | boolean) {
+  const id = String(value || '')
+  if (!id || id === activeCrawl.value?.id) return
+  await loadCrawl(id)
+  updateCrawlRouteOnMap()
+  fitMapToCrawlStops()
 }
 
 async function addSelectedVenueToCrawl() {
@@ -288,6 +366,14 @@ const SOURCE_ID = 'venue-clusters'
 const LAYER_CLUSTERS = 'venue-clusters-circle'
 const LAYER_CLUSTER_COUNT = 'venue-clusters-count'
 const LAYER_UNCLUSTERED = 'venue-unclustered-point'
+
+const CRAWL_ROUTE_SOURCE = 'crawl-route'
+const CRAWL_STOPS_SOURCE = 'crawl-stops'
+const CRAWL_LABELS_SOURCE = 'crawl-distance-labels'
+const CRAWL_ROUTE_LAYER = 'crawl-route-line'
+const CRAWL_STOPS_CIRCLE = 'crawl-stops-circle'
+const CRAWL_STOPS_NUMBER = 'crawl-stops-number'
+const CRAWL_DISTANCE_LAYER = 'crawl-distance-label'
 
 type MapVenuePoint = {
   id: number
@@ -478,13 +564,24 @@ async function createMap() {
     })
 
     map.value.addControl(new mapboxgl.NavigationControl(), 'bottom-right')
+    map.value.addControl(
+      new mapboxgl.GeolocateControl({
+        positionOptions: { enableHighAccuracy: true },
+        trackUserLocation: true,
+        showUserHeading: true,
+      }),
+      'bottom-right',
+    )
 
     map.value.on('load', () => {
       map.value.resize()
       ensureClusterLayers()
+      ensureCrawlRouteLayers()
       bindClusterHandlers()
       updateMapLayer(venueName.value)
       void loadVenueClusters()
+      updateCrawlRouteOnMap()
+      if (isLoggedIn.value) startCrawlGeolocation()
     })
   } catch (err) {
     console.error('Failed to create map:', err)
@@ -854,9 +951,259 @@ function updateDesktopViewport() {
   isDesktopViewport.value = desktopMediaQuery?.matches ?? true
 }
 
+function emptyFeatureCollection() {
+  return { type: 'FeatureCollection' as const, features: [] as any[] }
+}
+
+function ensureCrawlRouteLayers() {
+  if (!map.value) return
+
+  if (!map.value.getSource(CRAWL_ROUTE_SOURCE)) {
+    map.value.addSource(CRAWL_ROUTE_SOURCE, {
+      type: 'geojson',
+      data: emptyFeatureCollection(),
+    })
+  }
+  if (!map.value.getSource(CRAWL_STOPS_SOURCE)) {
+    map.value.addSource(CRAWL_STOPS_SOURCE, {
+      type: 'geojson',
+      data: emptyFeatureCollection(),
+    })
+  }
+  if (!map.value.getSource(CRAWL_LABELS_SOURCE)) {
+    map.value.addSource(CRAWL_LABELS_SOURCE, {
+      type: 'geojson',
+      data: emptyFeatureCollection(),
+    })
+  }
+
+  if (!map.value.getLayer(CRAWL_ROUTE_LAYER)) {
+    map.value.addLayer({
+      id: CRAWL_ROUTE_LAYER,
+      type: 'line',
+      source: CRAWL_ROUTE_SOURCE,
+      layout: {
+        'line-cap': 'round',
+        'line-join': 'round',
+      },
+      paint: {
+        'line-color': '#b45309',
+        'line-width': 3,
+        'line-dasharray': [1, 2],
+        'line-opacity': 0.9,
+      },
+    })
+  }
+
+  if (!map.value.getLayer(CRAWL_STOPS_CIRCLE)) {
+    map.value.addLayer({
+      id: CRAWL_STOPS_CIRCLE,
+      type: 'circle',
+      source: CRAWL_STOPS_SOURCE,
+      paint: {
+        'circle-radius': [
+          'case',
+          ['==', ['get', 'isCurrent'], 1],
+          11,
+          8,
+        ],
+        'circle-color': [
+          'case',
+          ['==', ['get', 'isCurrent'], 1],
+          '#059669',
+          '#d97706',
+        ],
+        'circle-stroke-width': 2,
+        'circle-stroke-color': '#ffffff',
+      },
+    })
+  }
+
+  if (!map.value.getLayer(CRAWL_STOPS_NUMBER)) {
+    map.value.addLayer({
+      id: CRAWL_STOPS_NUMBER,
+      type: 'symbol',
+      source: CRAWL_STOPS_SOURCE,
+      layout: {
+        'text-field': ['get', 'stopNumber'],
+        'text-size': 11,
+        'text-font': ['Open Sans Bold', 'Arial Unicode MS Bold'],
+        'text-allow-overlap': true,
+      },
+      paint: {
+        'text-color': '#ffffff',
+      },
+    })
+  }
+
+  if (!map.value.getLayer(CRAWL_DISTANCE_LAYER)) {
+    map.value.addLayer({
+      id: CRAWL_DISTANCE_LAYER,
+      type: 'symbol',
+      source: CRAWL_LABELS_SOURCE,
+      layout: {
+        'text-field': ['get', 'label'],
+        'text-size': 12,
+        'text-font': ['Open Sans Semibold', 'Arial Unicode MS Bold'],
+        'text-offset': [0, -0.6],
+        'text-allow-overlap': true,
+      },
+      paint: {
+        'text-color': '#78350f',
+        'text-halo-color': '#fffbeb',
+        'text-halo-width': 1.5,
+      },
+    })
+  }
+}
+
+function updateCrawlRouteOnMap() {
+  if (!map.value?.getSource) return
+  if (!map.value.isStyleLoaded?.() && !map.value.loaded?.()) return
+
+  try {
+    ensureCrawlRouteLayers()
+  } catch {
+    return
+  }
+
+  const routeSource = map.value.getSource(CRAWL_ROUTE_SOURCE)
+  const stopsSource = map.value.getSource(CRAWL_STOPS_SOURCE)
+  const labelsSource = map.value.getSource(CRAWL_LABELS_SOURCE)
+  if (!routeSource || !stopsSource || !labelsSource) return
+
+  const coords = stops.value
+    .map((stop) => {
+      const lat = Number(stop.latitude)
+      const lng = Number(stop.longitude)
+      if (!Number.isFinite(lat) || !Number.isFinite(lng) || lat === 0 || lng === 0) return null
+      return [lng, lat] as [number, number]
+    })
+    .filter(Boolean) as [number, number][]
+
+  const stopFeatures = stops.value.flatMap((stop, index) => {
+    const lat = Number(stop.latitude)
+    const lng = Number(stop.longitude)
+    if (!Number.isFinite(lat) || !Number.isFinite(lng) || lat === 0 || lng === 0) return []
+    return [{
+      type: 'Feature' as const,
+      geometry: { type: 'Point' as const, coordinates: [lng, lat] },
+      properties: {
+        stopNumber: String(index + 1),
+        name: stop.venueName,
+        isCurrent: index === currentStopIndex.value ? 1 : 0,
+      },
+    }]
+  })
+
+  const labelFeatures = legs.value.flatMap((leg) => {
+    if (leg.midLat == null || leg.midLng == null || !leg.shortLabel || leg.shortLabel === '?') return []
+    return [{
+      type: 'Feature' as const,
+      geometry: {
+        type: 'Point' as const,
+        coordinates: [leg.midLng, leg.midLat],
+      },
+      properties: {
+        label: leg.shortLabel,
+      },
+    }]
+  })
+
+  routeSource.setData({
+    type: 'FeatureCollection',
+    features: coords.length >= 2
+      ? [{
+          type: 'Feature',
+          geometry: {
+            type: 'LineString',
+            coordinates: coords,
+          },
+          properties: {},
+        }]
+      : [],
+  })
+  stopsSource.setData({ type: 'FeatureCollection', features: stopFeatures })
+  labelsSource.setData({ type: 'FeatureCollection', features: labelFeatures })
+}
+
+function fitMapToCrawlStops() {
+  if (!map.value || !mapboxgl) return
+  const points = stops.value
+    .map((stop) => {
+      const lat = Number(stop.latitude)
+      const lng = Number(stop.longitude)
+      if (!Number.isFinite(lat) || !Number.isFinite(lng) || lat === 0 || lng === 0) return null
+      return [lng, lat] as [number, number]
+    })
+    .filter(Boolean) as [number, number][]
+
+  if (!points.length) return
+  if (points.length === 1) {
+    map.value.flyTo({ center: points[0], zoom: 14 })
+    return
+  }
+
+  const bounds = points.reduce(
+    (b, coord) => b.extend(coord),
+    new mapboxgl.LngLatBounds(points[0], points[0]),
+  )
+  map.value.fitBounds(bounds, { padding: 64, maxZoom: 15, duration: 800 })
+}
+
+function startCrawlGeolocation() {
+  if (!import.meta.client || !navigator.geolocation) return
+  if (geoWatchId != null) return
+
+  geoWatchId = navigator.geolocation.watchPosition(
+    (position) => {
+      void handleCrawlGeolocation(position.coords.latitude, position.coords.longitude)
+    },
+    (err) => {
+      console.warn('Crawl geolocation unavailable:', err.message)
+    },
+    {
+      enableHighAccuracy: true,
+      maximumAge: 5000,
+      timeout: 20000,
+    },
+  )
+}
+
+function stopCrawlGeolocation() {
+  if (geoWatchId != null && navigator.geolocation) {
+    navigator.geolocation.clearWatch(geoWatchId)
+  }
+  geoWatchId = null
+  lastArrivalIndex = null
+}
+
+async function handleCrawlGeolocation(lat: number, lng: number) {
+  if (!activeCrawl.value || stops.value.length < 1) return
+
+  const nearest = findNearestStopIndex(lat, lng, stops.value, CRAWL_ARRIVAL_RADIUS_METERS)
+  if (!nearest) return
+  if (nearest.index === currentStopIndex.value) return
+  if (lastArrivalIndex === nearest.index) return
+
+  // Prefer arriving at the next stop in order, but also allow catching up if they skip
+  const ok = await setProgressAndSave(nearest.index, { fromArrival: true })
+  if (!ok) return
+
+  lastArrivalIndex = nearest.index
+  const stop = stops.value[nearest.index]
+  arrivalMessage.value = `You've arrived at stop ${nearest.index + 1}: ${stop?.venueName || 'pub'} (within ${CRAWL_ARRIVAL_RADIUS_METERS}m)`
+  if (arrivalMessageTimeout) clearTimeout(arrivalMessageTimeout)
+  arrivalMessageTimeout = setTimeout(() => {
+    arrivalMessage.value = ''
+  }, 6000)
+}
+
 onBeforeUnmount(() => {
   if (popupTimeout) clearTimeout(popupTimeout)
   if (crawlAddMessageTimeout) clearTimeout(crawlAddMessageTimeout)
+  if (arrivalMessageTimeout) clearTimeout(arrivalMessageTimeout)
+  stopCrawlGeolocation()
   desktopMediaQuery?.removeEventListener('change', updateDesktopViewport)
   popup?.remove()
   map.value?.remove()

--- a/pages/map/index.vue
+++ b/pages/map/index.vue
@@ -11,6 +11,8 @@
             color="white"
             class="min-w-[12rem]"
             :options="crawlSelectOptions"
+            option-attribute="label"
+            value-attribute="value"
             placeholder="Select crawl list…"
           />
           <UButton
@@ -284,6 +286,15 @@ watch(
     updateCrawlRouteOnMap()
   },
   { deep: true },
+)
+
+watch(
+  () => stops.value.map((s) => `${s.id}:${s.latitude}:${s.longitude}`).join('|'),
+  (next, prev) => {
+    if (!next || next === prev) return
+    // Fit when the active route's stop set changes (load / add / reorder coords)
+    fitMapToCrawlStops()
+  },
 )
 
 watch(isLoggedIn, (loggedIn) => {
@@ -1049,6 +1060,8 @@ function ensureCrawlRouteLayers() {
   }
 }
 
+let crawlRouteRequestId = 0
+
 function updateCrawlRouteOnMap() {
   if (!map.value?.getSource) return
   if (!map.value.isStyleLoaded?.() && !map.value.loaded?.()) return
@@ -1102,6 +1115,7 @@ function updateCrawlRouteOnMap() {
     }]
   })
 
+  // Straight dotted fallback immediately, then upgrade to walking directions when available
   routeSource.setData({
     type: 'FeatureCollection',
     features: coords.length >= 2
@@ -1117,6 +1131,46 @@ function updateCrawlRouteOnMap() {
   })
   stopsSource.setData({ type: 'FeatureCollection', features: stopFeatures })
   labelsSource.setData({ type: 'FeatureCollection', features: labelFeatures })
+
+  if (coords.length >= 2 && mapboxToken.value) {
+    const requestId = ++crawlRouteRequestId
+    void fetchWalkingRouteGeometry(coords).then((walkingCoords) => {
+      if (requestId !== crawlRouteRequestId) return
+      if (!walkingCoords?.length || !map.value?.getSource(CRAWL_ROUTE_SOURCE)) return
+      map.value.getSource(CRAWL_ROUTE_SOURCE).setData({
+        type: 'FeatureCollection',
+        features: [{
+          type: 'Feature',
+          geometry: {
+            type: 'LineString',
+            coordinates: walkingCoords,
+          },
+          properties: {},
+        }],
+      })
+    })
+  }
+}
+
+async function fetchWalkingRouteGeometry(coords: [number, number][]) {
+  if (!mapboxToken.value || coords.length < 2) return null
+  // Mapbox Directions allows up to 25 coordinates per request
+  const limited = coords.slice(0, 25)
+  const path = limited.map(([lng, lat]) => `${lng},${lat}`).join(';')
+  const url =
+    `https://api.mapbox.com/directions/v5/mapbox/walking/${path}`
+    + `?geometries=geojson&overview=full&access_token=${encodeURIComponent(mapboxToken.value)}`
+
+  try {
+    const data = await $fetch<{
+      routes?: Array<{ geometry?: { coordinates?: [number, number][] } }>
+    }>(url)
+    const geometry = data.routes?.[0]?.geometry?.coordinates
+    return geometry?.length ? geometry : null
+  } catch (err) {
+    console.warn('Walking directions unavailable, using straight crawl line:', err)
+    return null
+  }
 }
 
 function fitMapToCrawlStops() {

--- a/utils/crawl-distance.ts
+++ b/utils/crawl-distance.ts
@@ -1,9 +1,13 @@
 /** Approx walking distance helpers for pub crawl legs (client + server safe). */
 
 const EARTH_RADIUS_MILES = 3958.7613
+const EARTH_RADIUS_METERS = 6371000
 const WALKING_MPH = 3.1
 /** Typical walking routes are longer than crow-flies; ~1.25x is a common urban factor. */
 const WALK_ROUTE_FACTOR = 1.25
+
+/** Arrival radius for auto check-in at a crawl stop. */
+export const CRAWL_ARRIVAL_RADIUS_METERS = 50
 
 export function haversineMiles(lat1: number, lon1: number, lat2: number, lon2: number) {
   const toRad = (d: number) => (d * Math.PI) / 180
@@ -11,6 +15,16 @@ export function haversineMiles(lat1: number, lon1: number, lat2: number, lon2: n
     Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.cos(toRad(lon2 - lon1))
     + Math.sin(toRad(lat1)) * Math.sin(toRad(lat2))
   return EARTH_RADIUS_MILES * Math.acos(Math.min(1, Math.max(-1, a)))
+}
+
+export function haversineMeters(lat1: number, lon1: number, lat2: number, lon2: number) {
+  const toRad = (d: number) => (d * Math.PI) / 180
+  const dLat = toRad(lat2 - lat1)
+  const dLon = toRad(lon2 - lon1)
+  const a =
+    Math.sin(dLat / 2) ** 2
+    + Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2
+  return 2 * EARTH_RADIUS_METERS * Math.asin(Math.min(1, Math.sqrt(a)))
 }
 
 export function estimateWalkingMiles(lat1: number, lon1: number, lat2: number, lon2: number) {
@@ -32,11 +46,26 @@ export function formatWalkingDistance(miles: number) {
   return `~${milesLabel} mi · ${mins} min walk`
 }
 
+/** Shorter label for map mid-point markers. */
+export function formatWalkingDistanceShort(miles: number) {
+  if (!Number.isFinite(miles) || miles < 0) return ''
+  if (miles < 0.1) {
+    const meters = Math.round(miles * 1609.344)
+    return `~${meters} m`
+  }
+  const mins = estimateWalkingMinutes(miles)
+  const milesLabel = miles < 10 ? miles.toFixed(1) : Math.round(miles).toString()
+  return `~${milesLabel} mi · ${mins} min`
+}
+
 export type CrawlLeg = {
   fromIndex: number
   toIndex: number
   miles: number | null
   label: string
+  shortLabel: string
+  midLat: number | null
+  midLng: number | null
 }
 
 export function buildCrawlLegs(
@@ -55,7 +84,15 @@ export function buildCrawlLegs(
       || !Number.isFinite(lat1) || !Number.isFinite(lon1)
       || !Number.isFinite(lat2) || !Number.isFinite(lon2)
     ) {
-      legs.push({ fromIndex: i, toIndex: i + 1, miles: null, label: 'Distance unknown' })
+      legs.push({
+        fromIndex: i,
+        toIndex: i + 1,
+        miles: null,
+        label: 'Distance unknown',
+        shortLabel: '?',
+        midLat: null,
+        midLng: null,
+      })
       continue
     }
     const miles = estimateWalkingMiles(lat1, lon1, lat2, lon2)
@@ -64,7 +101,31 @@ export function buildCrawlLegs(
       toIndex: i + 1,
       miles,
       label: formatWalkingDistance(miles),
+      shortLabel: formatWalkingDistanceShort(miles),
+      midLat: (lat1 + lat2) / 2,
+      midLng: (lon1 + lon2) / 2,
     })
   }
   return legs
+}
+
+export function findNearestStopIndex(
+  lat: number,
+  lng: number,
+  stops: Array<{ latitude?: number | null; longitude?: number | null }>,
+  radiusMeters = CRAWL_ARRIVAL_RADIUS_METERS,
+) {
+  let bestIndex = -1
+  let bestMeters = Infinity
+  for (let i = 0; i < stops.length; i++) {
+    const stop = stops[i]
+    if (stop.latitude == null || stop.longitude == null) continue
+    if (!Number.isFinite(stop.latitude) || !Number.isFinite(stop.longitude)) continue
+    const meters = haversineMeters(lat, lng, stop.latitude, stop.longitude)
+    if (meters <= radiusMeters && meters < bestMeters) {
+      bestMeters = meters
+      bestIndex = i
+    }
+  }
+  return bestIndex >= 0 ? { index: bestIndex, meters: bestMeters } : null
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Continues pub crawl work as **PR #28** (separate from the earlier add/search fixes).

### Multiple crawl lists
- Create as many lists as you want with **New list**
- Switch the active list from the map toolbar dropdown
- “Add to …” always targets the selected list
- Most recently used list is restored on load

### Map route overlay
- Dotted path between stops (Mapbox **walking** directions when available, straight-line fallback)
- Numbered stop markers (current stop in green)
- Estimated walking distance labels between pubs
- Map fits to the active crawl route

### Auto check-in (50m)
- Watches device location on `/map`
- Within 50m of a stop, progress advances and saves automatically
- Arrival banner confirms which pub you reached

## Test
1. Create two crawl lists → switch via toolbar selector
2. Add 3+ pubs with coords → dotted walking line + distance labels
3. Allow location → approach a stop within 50m → progress updates

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f115d295-b0d1-4947-b408-4e43bc3859e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f115d295-b0d1-4947-b408-4e43bc3859e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

