### PR TITLE
Toggle map crawl button: Add ↔ Remove when venue already on list

### DIFF
--- a/components/map/PubCrawlBuilder.vue
+++ b/components/map/PubCrawlBuilder.vue
@@ -138,7 +138,7 @@
         <section class="space-y-2">
           <h3 class="text-sm font-semibold text-gray-900 dark:text-white">Add a pub</h3>
           <p class="text-xs text-gray-500">
-            Click a pub on the map and use “Add to crawl”, or search by name below.
+            Click a pub on the map and use “Add to …” / “Remove from …”, or search by name below.
           </p>
           <div class="relative">
             <UInput

--- a/composables/usePubCrawl.ts
+++ b/composables/usePubCrawl.ts
@@ -324,6 +324,63 @@ export function usePubCrawl() {
     markDirty()
   }
 
+  function isVenueOnActiveCrawl(venueId: number | null | undefined) {
+    if (!venueId) return false
+    if (stops.value.some((s) => s.venueId === venueId)) return true
+    // Fallback while the active crawl's stops are still hydrating
+    return (activeCrawl.value?.stops || []).some((s) => s.venueId === venueId)
+  }
+
+  /** Remove a map venue from the active crawl and persist immediately. */
+  async function removeVenueStop(venueId: number) {
+    if (!activeCrawl.value) {
+      errorMessage.value = 'Open or create a crawl first.'
+      return false
+    }
+
+    if (!stops.value.length && (activeCrawl.value.stopCount || 0) > 0) {
+      await loadCrawl(activeCrawl.value.id)
+    }
+
+    const stop = stops.value.find((s) => s.venueId === venueId)
+    if (!stop) {
+      errorMessage.value = 'That pub is not on this crawl.'
+      return false
+    }
+
+    addingStop.value = true
+    errorMessage.value = ''
+    try {
+      await useAuthFetch(`/api/crawls/${activeCrawl.value.id}/stops/${stop.id}`, {
+        method: 'DELETE',
+      })
+
+      const nextStops = stops.value.filter((s) => s.id !== stop.id)
+      stops.value = nextStops
+      if (currentStopIndex.value >= nextStops.length) {
+        currentStopIndex.value = Math.max(0, nextStops.length - 1)
+      }
+
+      dirty.value = false
+      lastSavedAt.value = 'just now'
+      await loadCrawls()
+      if (activeCrawl.value) {
+        activeCrawl.value = {
+          ...activeCrawl.value,
+          stopCount: nextStops.length,
+          currentStopIndex: currentStopIndex.value,
+          stops: nextStops,
+        }
+      }
+      return true
+    } catch (err: any) {
+      errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not remove pub from crawl'
+      return false
+    } finally {
+      addingStop.value = false
+    }
+  }
+
   function setProgress(index: number) {
     if (index < 0 || index >= stops.value.length) return
     currentStopIndex.value = index
@@ -430,6 +487,8 @@ export function usePubCrawl() {
     addManualStop,
     addVenueStop,
     removeStopLocal,
+    isVenueOnActiveCrawl,
+    removeVenueStop,
     setProgress,
     setProgressAndSave,
     reorderStops,

--- a/pages/map/index.vue
+++ b/pages/map/index.vue
@@ -184,15 +184,21 @@
             />
             <UButton
               v-if="isLoggedIn"
-              color="amber"
+              :color="selectedVenueOnActiveCrawl ? 'red' : 'amber'"
               variant="soft"
-              icon="i-heroicons-plus-20-solid"
-              :label="addToCrawlLabel"
+              :icon="selectedVenueOnActiveCrawl ? 'i-heroicons-minus-20-solid' : 'i-heroicons-plus-20-solid'"
+              :label="crawlToggleLabel"
               :loading="crawlAddPending"
-              @click="addSelectedVenueToCrawl"
+              @click="toggleSelectedVenueOnCrawl"
             />
           </div>
-          <p v-if="crawlAddMessage" class="text-sm text-emerald-700 dark:text-emerald-400">
+          <p
+            v-if="crawlAddMessage"
+            class="text-sm"
+            :class="crawlAddMessageIsError
+              ? 'text-red-600 dark:text-red-400'
+              : 'text-emerald-700 dark:text-emerald-400'"
+          >
             {{ crawlAddMessage }}
           </p>
         </div>
@@ -229,6 +235,8 @@ const {
   legs,
   currentStopIndex,
   addVenueStop,
+  removeVenueStop,
+  isVenueOnActiveCrawl,
   loadCrawl,
   setProgressAndSave,
   initialize: initializePubCrawl,
@@ -240,6 +248,7 @@ const cityNames = computed(() => eventStore.cities.map((city) => city.name))
 
 const isCrawlBuilderOpen = ref(false)
 const crawlAddMessage = ref('')
+const crawlAddMessageIsError = ref(false)
 const crawlAddPending = ref(false)
 const arrivalMessage = ref('')
 const selectedCrawlId = ref('')
@@ -261,9 +270,18 @@ const crawlButtonLabel = computed(() => {
     ? `Manage · ${crawls.value.length} lists`
     : `Manage · ${activeCrawl.value.name}`
 })
-const addToCrawlLabel = computed(() =>
-  activeCrawl.value?.name ? `Add to ${activeCrawl.value.name}` : 'Add to crawl',
+
+const selectedVenueOnActiveCrawl = computed(() =>
+  isVenueOnActiveCrawl(selectedVenue.value?.id),
 )
+
+const crawlToggleLabel = computed(() => {
+  const name = activeCrawl.value?.name
+  if (selectedVenueOnActiveCrawl.value) {
+    return name ? `Remove from ${name}` : 'Remove from crawl'
+  }
+  return name ? `Add to ${name}` : 'Add to crawl'
+})
 
 watch(
   () => activeCrawl.value?.id,
@@ -305,6 +323,7 @@ watch(isLoggedIn, (loggedIn) => {
 function openCrawlBuilder() {
   isCrawlBuilderOpen.value = true
   crawlAddMessage.value = ''
+  crawlAddMessageIsError.value = false
 }
 
 function onCrawlUpdated(_crawl: { id: string; name: string } | null) {
@@ -312,13 +331,43 @@ function onCrawlUpdated(_crawl: { id: string; name: string } | null) {
   updateCrawlRouteOnMap()
 }
 
-async function addSelectedVenueToCrawl() {
+function showCrawlToggleMessage(message: string, isError = false) {
+  crawlAddMessage.value = message
+  crawlAddMessageIsError.value = isError
+  if (crawlAddMessageTimeout) clearTimeout(crawlAddMessageTimeout)
+  crawlAddMessageTimeout = setTimeout(() => {
+    crawlAddMessage.value = ''
+    crawlAddMessageIsError.value = false
+  }, 4000)
+}
+
+async function toggleSelectedVenueOnCrawl() {
   if (!selectedVenue.value || crawlAddPending.value) return
   crawlAddMessage.value = ''
+  crawlAddMessageIsError.value = false
   crawlAddPending.value = true
+
+  const venueName = selectedVenue.value.name
+  const crawlName = activeCrawl.value?.name || 'your crawl'
+  const removing = selectedVenueOnActiveCrawl.value
 
   try {
     await initializePubCrawl()
+
+    if (removing) {
+      const ok = await removeVenueStop(selectedVenue.value.id)
+      if (ok) {
+        showCrawlToggleMessage(`Removed ${venueName} from ${crawlName}.`)
+      } else {
+        isCrawlBuilderOpen.value = true
+        showCrawlToggleMessage(
+          crawlErrorMessage.value || 'Could not remove this pub from the crawl.',
+          true,
+        )
+      }
+      return
+    }
+
     const ok = await addVenueStop({
       id: selectedVenue.value.id,
       name: selectedVenue.value.name,
@@ -328,18 +377,22 @@ async function addSelectedVenueToCrawl() {
 
     if (ok) {
       isCrawlBuilderOpen.value = true
-      crawlAddMessage.value = `Added ${selectedVenue.value.name} to ${activeCrawl.value?.name || 'your crawl'}.`
-      if (crawlAddMessageTimeout) clearTimeout(crawlAddMessageTimeout)
-      crawlAddMessageTimeout = setTimeout(() => {
-        crawlAddMessage.value = ''
-      }, 4000)
+      showCrawlToggleMessage(`Added ${venueName} to ${crawlName}.`)
     } else {
       isCrawlBuilderOpen.value = true
-      crawlAddMessage.value = crawlErrorMessage.value || 'Could not add this pub — create or open a crawl first.'
+      showCrawlToggleMessage(
+        crawlErrorMessage.value || 'Could not add this pub — create or open a crawl first.',
+        true,
+      )
     }
   } catch (err: any) {
     isCrawlBuilderOpen.value = true
-    crawlAddMessage.value = err?.data?.statusMessage || err?.message || 'Could not add this pub to the crawl.'
+    showCrawlToggleMessage(
+      err?.data?.statusMessage
+        || err?.message
+        || (removing ? 'Could not remove this pub from the crawl.' : 'Could not add this pub to the crawl.'),
+      true,
+    )
   } finally {
     crawlAddPending.value = false
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On the map venue modal, if the selected pub is already on the active crawl list, show **Remove from [crawl name]** instead of **Add to [crawl name]**.

## Behavior

- Detect membership via the active crawl’s stops (`venueId`)
- Remove persists immediately via `DELETE /api/crawls/[id]/stops/[stopId]`
- Button switches icon/color (minus / red soft) when removing
- Help copy in the crawl builder mentions Add / Remove

## Files

- `composables/usePubCrawl.ts` — `isVenueOnActiveCrawl`, `removeVenueStop`
- `pages/map/index.vue` — toggle button label + handler
- `components/map/PubCrawlBuilder.vue` — help text
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f115d295-b0d1-4947-b408-4e43bc3859e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f115d295-b0d1-4947-b408-4e43bc3859e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

