### PR TITLE
Tidy map venue modal onto master (map, no nulls, actions up)

### DIFF
--- a/pages/map/index.vue
+++ b/pages/map/index.vue
@@ -122,7 +122,51 @@
             variant="soft"
             :description="venueDetailsError"
           />
-          <template v-else>
+          <div
+            v-if="selectedVenueStaticMapUrl"
+            class="overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800"
+          >
+            <img
+              :src="selectedVenueStaticMapUrl"
+              :alt="`Map showing ${selectedVenue.name}`"
+              class="h-48 w-full object-cover sm:h-56"
+              loading="lazy"
+            >
+          </div>
+          <div class="flex flex-wrap items-center justify-center gap-2">
+            <UButton
+              v-if="selectedVenue.id"
+              color="amber"
+              variant="solid"
+              :to="selectedVenueUrl"
+              label="View venue"
+            />
+            <UButton
+              color="gray"
+              variant="soft"
+              label="Events"
+              @click="openSelectedVenueEvents"
+            />
+            <UButton
+              v-if="isLoggedIn"
+              :color="selectedVenueOnActiveCrawl ? 'red' : 'amber'"
+              variant="soft"
+              :icon="selectedVenueOnActiveCrawl ? 'i-heroicons-minus-20-solid' : 'i-heroicons-plus-20-solid'"
+              :label="crawlToggleLabel"
+              :loading="crawlAddPending"
+              @click="toggleSelectedVenueOnCrawl"
+            />
+          </div>
+          <p
+            v-if="crawlAddMessage"
+            class="text-center text-sm"
+            :class="crawlAddMessageIsError
+              ? 'text-red-600 dark:text-red-400'
+              : 'text-emerald-700 dark:text-emerald-400'"
+          >
+            {{ crawlAddMessage }}
+          </p>
+          <template v-if="!isVenueDetailsLoading && !venueDetailsError">
             <p
               v-if="selectedVenueAddressLines.length"
               class="text-sm leading-6 text-gray-700 dark:text-gray-200"
@@ -153,51 +197,7 @@
             >
               {{ selectedVenueDescription }}
             </p>
-            <div
-              v-if="selectedVenueStaticMapUrl"
-              class="overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800"
-            >
-              <img
-                :src="selectedVenueStaticMapUrl"
-                :alt="`Map showing ${selectedVenue.name}`"
-                class="h-48 w-full object-cover sm:h-56"
-                loading="lazy"
-              >
-            </div>
           </template>
-          <div class="flex flex-wrap gap-2">
-            <UButton
-              v-if="selectedVenue.id"
-              color="amber"
-              variant="solid"
-              :to="selectedVenueUrl"
-              label="View venue"
-            />
-            <UButton
-              color="gray"
-              variant="soft"
-              label="Events"
-              @click="openSelectedVenueEvents"
-            />
-            <UButton
-              v-if="isLoggedIn"
-              :color="selectedVenueOnActiveCrawl ? 'red' : 'amber'"
-              variant="soft"
-              :icon="selectedVenueOnActiveCrawl ? 'i-heroicons-minus-20-solid' : 'i-heroicons-plus-20-solid'"
-              :label="crawlToggleLabel"
-              :loading="crawlAddPending"
-              @click="toggleSelectedVenueOnCrawl"
-            />
-          </div>
-          <p
-            v-if="crawlAddMessage"
-            class="text-sm"
-            :class="crawlAddMessageIsError
-              ? 'text-red-600 dark:text-red-400'
-              : 'text-emerald-700 dark:text-emerald-400'"
-          >
-            {{ crawlAddMessage }}
-          </p>
         </div>
       </UCard>
     </UModal>

--- a/pages/map/index.vue
+++ b/pages/map/index.vue
@@ -113,15 +113,6 @@
           </div>
         </template>
         <div class="space-y-5">
-          <div v-if="isVenueDetailsLoading" class="text-sm text-gray-500 dark:text-gray-400">
-            Loading venue details...
-          </div>
-          <UAlert
-            v-else-if="venueDetailsError"
-            color="red"
-            variant="soft"
-            :description="venueDetailsError"
-          />
           <div
             v-if="selectedVenueStaticMapUrl"
             class="overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800"
@@ -166,7 +157,16 @@
           >
             {{ crawlAddMessage }}
           </p>
-          <template v-if="!isVenueDetailsLoading && !venueDetailsError">
+          <div v-if="isVenueDetailsLoading" class="text-sm text-gray-500 dark:text-gray-400">
+            Loading venue details...
+          </div>
+          <UAlert
+            v-else-if="venueDetailsError"
+            color="red"
+            variant="soft"
+            :description="venueDetailsError"
+          />
+          <template v-else>
             <p
               v-if="selectedVenueAddressLines.length"
               class="text-sm leading-6 text-gray-700 dark:text-gray-200"

--- a/pages/map/index.vue
+++ b/pages/map/index.vue
@@ -108,9 +108,6 @@
               <h3 class="text-base font-semibold leading-6 text-gray-900 dark:text-white">
                 {{ selectedVenue.name }}
               </h3>
-              <p v-if="selectedVenueDetails?.venuetype" class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                {{ selectedVenueDetails.venuetype }}
-              </p>
             </div>
             <UButton color="gray" variant="ghost" icon="i-heroicons-x-mark-20-solid" class="-my-1" @click="closeVenueModal" />
           </div>
@@ -126,39 +123,22 @@
             :description="venueDetailsError"
           />
           <template v-else>
-            <div v-if="selectedVenuePhotoUrl" class="overflow-hidden rounded-lg bg-gray-100">
-              <img
-                :src="selectedVenuePhotoUrl"
-                :alt="selectedVenueDetails.venuename || selectedVenue.name"
-                class="max-h-64 w-full object-cover"
-              >
-            </div>
-            <p v-if="selectedVenueDetails?.description" class="text-sm leading-6 text-gray-700 dark:text-gray-200">
-              {{ selectedVenueDetails.description }}
+            <p
+              v-if="selectedVenueAddressLines.length"
+              class="text-sm leading-6 text-gray-700 dark:text-gray-200"
+            >
+              {{ selectedVenueAddressLines.join(', ') }}
             </p>
-            <div class="grid gap-3 text-sm sm:grid-cols-2">
-              <div
-                v-for="detail in selectedVenueDetailRows"
-                :key="detail.label"
-                class="rounded-md border border-gray-200 p-3 dark:border-gray-800"
+            <p v-if="selectedVenueWebsiteHref" class="text-sm">
+              <a
+                :href="selectedVenueWebsiteHref"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-amber-700 hover:text-amber-800 dark:text-amber-400 dark:hover:text-amber-300"
               >
-                <dt class="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                  {{ detail.label }}
-                </dt>
-                <dd class="mt-1 break-words text-gray-900 dark:text-white">
-                  <a
-                    v-if="detail.href"
-                    :href="detail.href"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="text-amber-700 hover:text-amber-800"
-                  >
-                    {{ detail.value }}
-                  </a>
-                  <span v-else>{{ detail.value }}</span>
-                </dd>
-              </div>
-            </div>
+                {{ selectedVenueWebsiteLabel }}
+              </a>
+            </p>
             <div v-if="selectedVenueFeatureLines.length" class="text-sm text-gray-700 dark:text-gray-200">
               <h4 class="mb-2 font-semibold text-gray-900 dark:text-white">Features</h4>
               <ul class="space-y-1">
@@ -166,6 +146,23 @@
                   {{ feature }}
                 </li>
               </ul>
+            </div>
+            <p
+              v-if="selectedVenueDescription"
+              class="text-sm leading-6 text-gray-700 dark:text-gray-200"
+            >
+              {{ selectedVenueDescription }}
+            </p>
+            <div
+              v-if="selectedVenueStaticMapUrl"
+              class="overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800"
+            >
+              <img
+                :src="selectedVenueStaticMapUrl"
+                :alt="`Map showing ${selectedVenue.name}`"
+                class="h-48 w-full object-cover sm:h-56"
+                loading="lazy"
+              >
             </div>
           </template>
           <div class="flex flex-wrap gap-2">
@@ -211,7 +208,7 @@
 import { ref, reactive, onMounted, computed, watch } from 'vue'
 import { useVenueStore } from '@/store/venue.js'
 import { useEventStore } from '@/store/event.js'
-import { resolveVenueDisplayPhotoUrl } from '@/utils/format-venue'
+import { venueStaticMapUrl } from '@/utils/format-venue'
 import {
   CRAWL_ARRIVAL_RADIUS_METERS,
   findNearestStopIndex,
@@ -226,7 +223,6 @@ useSiteSeo({
 const venueStore = useVenueStore()
 const eventStore = useEventStore()
 const mapboxToken = useMapboxToken()
-const config = useRuntimeConfig()
 const { isLoggedIn, initializeAuth } = useAuth()
 const {
   crawls,
@@ -517,45 +513,33 @@ const selectedVenueFeatureLines = computed(() => {
     .map((line) => line.trim())
     .filter(Boolean)
 })
-const selectedVenuePhotoUrl = computed(() => {
-  const photo = readVenueString(selectedVenueDetails.value, 'photo')
-  if (!photo) return ''
-  return resolveVenueDisplayPhotoUrl(photo, {
-    venueImgFolder: config.public.venueImgFolder as string | undefined,
-    supabaseUrl: config.public.supabase?.url as string | undefined,
-  })
+const selectedVenueDescription = computed(() => {
+  const description = readVenueString(selectedVenueDetails.value, 'description')
+  return description && description.toLowerCase() !== 'null' ? description : ''
 })
-const selectedVenueDetailRows = computed(() => {
-  const venue = selectedVenueDetails.value
-  if (!venue) return []
-
-  const website = readVenueString(venue, 'website')
-  const telephone = readVenueString(venue, 'telephone')
-  const rows: Array<{ label: string; value: string; href?: string }> = [
-    { label: 'Venue name', value: readVenueString(venue, 'venuename') },
-    { label: 'Venue type', value: readVenueString(venue, 'venuetype') },
-    { label: 'Address', value: selectedVenueAddressLines.value.join(', ') },
-    { label: 'Telephone', value: telephone, href: telephoneHref(telephone) },
-    { label: 'Website', value: website, href: websiteHref(website) },
-    { label: 'Town', value: readVenueString(venue, 'town') },
-    { label: 'County', value: readVenueString(venue, 'county') },
-    { label: 'Postcode', value: readVenueString(venue, 'postcode') },
-    { label: 'Postcode search', value: readVenueString(venue, 'postalsearch') },
-    { label: 'Local authority', value: readVenueString(venue, 'local_authority') },
-    { label: 'Latitude', value: readVenueString(venue, 'latitude') },
-    { label: 'Longitude', value: readVenueString(venue, 'longitude') },
-    { label: 'Easting', value: readVenueString(venue, 'easting') },
-    { label: 'Northing', value: readVenueString(venue, 'northing') },
-    { label: 'Photo', value: readVenueString(venue, 'photo'), href: photoHref(readVenueString(venue, 'photo')) },
-    { label: 'Live status', value: readVenueString(venue, 'is_live') },
-    { label: 'Venue ID', value: readVenueString(venue, 'id') },
-    { label: 'FSA ID', value: readVenueString(venue, 'fsa_id') },
-    { label: 'Slug', value: readVenueString(venue, 'slug') },
-    { label: 'Created', value: readVenueString(venue, 'created_at') },
-    { label: 'Updated', value: readVenueString(venue, 'updated_at') },
-  ]
-
-  return rows.filter((row) => row.value)
+const selectedVenueWebsite = computed(() => {
+  const website = readVenueString(selectedVenueDetails.value, 'website')
+  if (!website || website.toLowerCase() === 'null') return ''
+  return website
+})
+const selectedVenueWebsiteHref = computed(() => websiteHref(selectedVenueWebsite.value))
+const selectedVenueWebsiteLabel = computed(() => {
+  const website = selectedVenueWebsite.value
+  if (!website) return ''
+  return website.replace(/^https?:\/\//i, '').replace(/\/$/, '')
+})
+const selectedVenueStaticMapUrl = computed(() => {
+  if (!mapboxToken.value || !selectedVenue.value) return ''
+  const details = selectedVenueDetails.value
+  return venueStaticMapUrl(
+    {
+      latitude: details?.latitude ?? selectedVenue.value.lat,
+      longitude: details?.longitude ?? selectedVenue.value.lng,
+    },
+    mapboxToken.value,
+    640,
+    240,
+  ) || ''
 })
 
 let desktopMediaQuery: MediaQueryList | null = null
@@ -986,21 +970,15 @@ async function fetchVenueDetailsForPopup(id: number, venuename: unknown, coordin
 
 function readVenueString(venue: object | null | undefined, key: string) {
   const value = (venue as Record<string, unknown> | null | undefined)?.[key]
-  return value == null ? '' : String(value).trim()
-}
-
-function telephoneHref(value: string) {
-  const cleaned = value.replace(/[^\d+]/g, '')
-  return cleaned ? `tel:${cleaned}` : ''
+  if (value == null) return ''
+  const text = String(value).trim()
+  if (!text || text.toLowerCase() === 'null' || text.toLowerCase() === 'undefined') return ''
+  return text
 }
 
 function websiteHref(value: string) {
   if (!value) return ''
   return /^https?:\/\//i.test(value) ? value : `https://${value}`
-}
-
-function photoHref(value: string) {
-  return /^https?:\/\//i.test(value) ? value : ''
 }
 
 function updateDesktopViewport() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Re-applies the map venue modal tidy that was done in #31 but **never landed on `master`** (that PR was merged into a feature branch only).

## Modal layout now

1. Venue name
2. Location **map with marker** (replaces lat/lng text)
3. Centered actions: View venue / Events / Add or Remove from crawl
4. Address, website, features, description — only when present

## Removed

- Latitude, Longitude, Easting, Northing
- Live status, Venue ID, Slug, Created / Updated
- Empty / null detail cells
- Crowded detail grid

No new feature work beyond bringing this onto `master`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f115d295-b0d1-4947-b408-4e43bc3859e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f115d295-b0d1-4947-b408-4e43bc3859e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

