### PR TITLE
Invitee dashboard: accept invites, hide owner actions

### DIFF
--- a/components/crawl/DashboardCard.vue
+++ b/components/crawl/DashboardCard.vue
@@ -7,11 +7,11 @@
             <h3 class="text-base font-semibold text-gray-900 dark:text-white">{{ crawl.name }}</h3>
             <span
               class="rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide"
-              :class="crawl.canEdit
+              :class="isOwner
                 ? 'bg-amber-100 text-amber-900 dark:bg-amber-900 dark:text-amber-100'
                 : 'bg-sky-100 text-sky-900 dark:bg-sky-900 dark:text-sky-100'"
             >
-              {{ crawl.canEdit ? 'Creator' : 'View only' }}
+              {{ isOwner ? 'Creator' : 'Invited' }}
             </span>
             <span
               v-if="crawl.completedAt"
@@ -21,6 +21,10 @@
             </span>
           </div>
           <p class="mt-1 text-sm text-gray-500">
+            <template v-if="!isOwner && invitedByLabel">
+              Invited by {{ invitedByLabel }}
+              ·
+            </template>
             {{ crawl.stopCount }} stop{{ crawl.stopCount === 1 ? '' : 's' }}
             <template v-if="crawl.stopCount">
               · progress {{ Math.min(crawl.currentStopIndex + 1, crawl.stopCount) }}/{{ crawl.stopCount }}
@@ -30,7 +34,7 @@
         <div class="flex flex-wrap gap-2">
           <UButton size="xs" color="amber" variant="soft" to="/map" label="View on map" />
           <UButton
-            v-if="crawl.canEdit"
+            v-if="isOwner"
             size="xs"
             color="gray"
             variant="soft"
@@ -38,7 +42,7 @@
             @click="$emit('invite')"
           />
           <UButton
-            v-if="crawl.canEdit && !crawl.completedAt"
+            v-if="isOwner && !crawl.completedAt"
             size="xs"
             color="emerald"
             variant="soft"
@@ -46,7 +50,7 @@
             @click="$emit('complete')"
           />
           <UButton
-            v-if="crawl.canEdit && crawl.completedAt"
+            v-if="isOwner && crawl.completedAt"
             size="xs"
             color="gray"
             variant="soft"
@@ -54,7 +58,7 @@
             @click="$emit('reopen')"
           />
           <UButton
-            v-if="crawl.canEdit"
+            v-if="isOwner"
             size="xs"
             color="red"
             variant="ghost"
@@ -98,6 +102,9 @@ const props = defineProps<{
     currentStopIndex: number
     completedAt: string | null
     canEdit: boolean
+    role?: 'owner' | 'member'
+    invitedBy?: { userId: string; username: string; displayName: string } | null
+    owner?: { userId: string; username: string; displayName: string } | null
     members?: Array<{
       userId: string
       username: string
@@ -116,10 +123,21 @@ const emit = defineEmits<{
   deleted: []
 }>()
 
+const isOwner = computed(() => props.crawl.role === 'owner' && props.crawl.canEdit === true)
+
+const invitedByLabel = computed(() => {
+  const inviter = props.crawl.invitedBy || props.crawl.owner
+  if (!inviter) return ''
+  if (inviter.displayName && inviter.username) {
+    return `${inviter.displayName} (@${inviter.username})`
+  }
+  return inviter.displayName || (inviter.username ? `@${inviter.username}` : '')
+})
+
 const deleting = ref(false)
 
 async function deleteCrawl() {
-  if (!props.crawl.canEdit) return
+  if (!isOwner.value) return
   if (!confirm(`Delete “${props.crawl.name}”? This cannot be undone.`)) return
   deleting.value = true
   try {

--- a/composables/usePubCrawl.ts
+++ b/composables/usePubCrawl.ts
@@ -84,7 +84,11 @@ export function usePubCrawl() {
   })
 
   const hasActiveCrawl = computed(() => !!activeCrawl.value)
-  const canEditActiveCrawl = computed(() => !!activeCrawl.value && activeCrawl.value.canEdit !== false && activeCrawl.value.role !== 'member')
+  const canEditActiveCrawl = computed(() =>
+    !!activeCrawl.value
+    && activeCrawl.value.canEdit === true
+    && activeCrawl.value.role === 'owner',
+  )
 
   function ensureCanEdit() {
     if (!canEditActiveCrawl.value) {

--- a/pages/pub-crawls/index.vue
+++ b/pages/pub-crawls/index.vue
@@ -4,12 +4,12 @@
       <div>
         <h1 class="text-2xl font-semibold text-gray-900 dark:text-white">Pub Crawls</h1>
         <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-          Your active crawl, invites, and shared lists.
-          <span v-if="profile">
-            Signed in as
-            <strong>{{ profile.displayName }}</strong>
-            <span class="text-gray-500 dark:text-gray-400"> (@{{ profile.username }})</span>
-          </span>
+          {{ pageSubtitle }}
+        </p>
+        <p v-if="profile" class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          Signed in as
+          <strong class="text-gray-700 dark:text-gray-300">{{ profile.displayName }}</strong>
+          (@{{ profile.username }})
         </p>
       </div>
       <div class="flex flex-wrap gap-2">
@@ -31,6 +31,53 @@
     <div v-if="loading && !loaded" class="text-sm text-gray-500">Loading pub crawls…</div>
 
     <template v-else>
+      <!-- Pending invites — always first so invitees can accept -->
+      <section v-if="pendingInvites.length" class="mb-8 space-y-3">
+        <div class="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 dark:border-amber-800 dark:bg-amber-950/40">
+          <h2 class="text-lg font-semibold text-amber-950 dark:text-amber-100">
+            {{ pendingInvites.length === 1 ? 'You have been invited' : `You have ${pendingInvites.length} invitations` }}
+          </h2>
+          <p class="mt-1 text-sm text-amber-900/80 dark:text-amber-200/80">
+            Accept an invite to view the crawl on the map. You will not be able to edit, invite, or delete it.
+          </p>
+        </div>
+
+        <UCard
+          v-for="invite in pendingInvites"
+          :key="invite.id"
+          :ui="{ body: { padding: 'p-4' }, ring: 'ring-1 ring-amber-300 dark:ring-amber-800' }"
+        >
+          <div class="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <p class="font-medium text-gray-900 dark:text-white">{{ invite.crawlName }}</p>
+              <p class="text-sm text-gray-600 dark:text-gray-400">
+                Invited by
+                <strong>{{ invite.invitedBy.displayName }}</strong>
+                (@{{ invite.invitedBy.username }})
+                · {{ invite.stopCount }} stop{{ invite.stopCount === 1 ? '' : 's' }}
+              </p>
+            </div>
+            <div class="flex gap-2">
+              <UButton
+                color="emerald"
+                size="sm"
+                :loading="respondingId === invite.id"
+                label="Accept invitation"
+                @click="respondInvite(invite.id, 'accept')"
+              />
+              <UButton
+                color="gray"
+                variant="soft"
+                size="sm"
+                :loading="respondingId === invite.id"
+                label="Decline"
+                @click="respondInvite(invite.id, 'decline')"
+              />
+            </div>
+          </div>
+        </UCard>
+      </section>
+
       <!-- Notifications -->
       <section v-if="notifications.length" class="mb-8 space-y-2">
         <div class="flex items-center justify-between gap-2">
@@ -60,50 +107,35 @@
           >
             <p class="font-medium text-gray-900 dark:text-white">{{ note.title }}</p>
             <p v-if="note.body" class="text-gray-600 dark:text-gray-400">{{ note.body }}</p>
-          </li>
-        </ul>
-      </section>
-
-      <!-- Pending invites -->
-      <section v-if="pendingInvites.length" class="mb-8 space-y-3">
-        <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Invitations</h2>
-        <UCard
-          v-for="invite in pendingInvites"
-          :key="invite.id"
-          :ui="{ body: { padding: 'p-4' } }"
-        >
-          <div class="flex flex-wrap items-center justify-between gap-3">
-            <div>
-              <p class="font-medium text-gray-900 dark:text-white">{{ invite.crawlName }}</p>
-              <p class="text-sm text-gray-500">
-                Invited by @{{ invite.invitedBy.username }}
-                · {{ invite.stopCount }} stop{{ invite.stopCount === 1 ? '' : 's' }}
-              </p>
-            </div>
-            <div class="flex gap-2">
+            <div
+              v-if="note.type === 'crawl_invite' && inviteIdForNotification(note)"
+              class="mt-2 flex flex-wrap gap-2"
+            >
               <UButton
                 color="emerald"
-                size="sm"
-                :loading="respondingId === invite.id"
-                label="Accept"
-                @click="respondInvite(invite.id, 'accept')"
+                size="xs"
+                :loading="respondingId === inviteIdForNotification(note)"
+                label="Accept invitation"
+                @click="respondInvite(inviteIdForNotification(note)!, 'accept')"
               />
               <UButton
                 color="gray"
                 variant="soft"
-                size="sm"
-                :loading="respondingId === invite.id"
+                size="xs"
+                :loading="respondingId === inviteIdForNotification(note)"
                 label="Decline"
-                @click="respondInvite(invite.id, 'decline')"
+                @click="respondInvite(inviteIdForNotification(note)!, 'decline')"
               />
             </div>
-          </div>
-        </UCard>
+          </li>
+        </ul>
       </section>
 
       <!-- Active -->
       <section class="mb-8 space-y-3">
-        <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Current active crawl</h2>
+        <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
+          {{ activeSectionTitle }}
+        </h2>
         <CrawlDashboardCard
           v-if="activeCrawl"
           :crawl="activeCrawl"
@@ -116,7 +148,7 @@
         <p v-else class="text-sm text-gray-500">
           No active crawl.
           <NuxtLink to="/map" class="text-amber-700 hover:underline">Create one on the map</NuxtLink>
-          or accept an invite above.
+          <template v-if="pendingInvites.length"> or accept an invite above.</template>
         </p>
       </section>
 
@@ -208,6 +240,7 @@
 <script setup lang="ts">
 definePageMeta({})
 
+const route = useRoute()
 const { isLoggedIn, initializeAuth } = useAuth()
 
 useSiteSeo({
@@ -234,14 +267,24 @@ type CrawlCard = {
   canEdit: boolean
   role: 'owner' | 'member'
   members: CrawlMember[]
+  owner?: Profile | null
+  invitedBy?: Profile | null
   updatedAt: string
+}
+type PendingInvite = {
+  id: string
+  crawlId: string
+  crawlName: string
+  stopCount: number
+  invitedBy: Profile
+  createdAt: string
 }
 
 const profile = ref<Profile | null>(null)
 const activeCrawl = ref<CrawlCard | null>(null)
 const otherCrawls = ref<CrawlCard[]>([])
 const completedCrawls = ref<CrawlCard[]>([])
-const pendingInvites = ref<any[]>([])
+const pendingInvites = ref<PendingInvite[]>([])
 const notifications = ref<any[]>([])
 const unreadNotificationCount = ref(0)
 const loading = ref(false)
@@ -258,6 +301,45 @@ const invitingUserId = ref<string | null>(null)
 const inviteMessage = ref('')
 let inviteTimer: ReturnType<typeof setTimeout> | null = null
 
+const pageSubtitle = computed(() => {
+  if (pendingInvites.value.length === 1) {
+    const invite = pendingInvites.value[0]
+    return `You have been invited by ${invite.invitedBy.displayName} (@${invite.invitedBy.username}) to join “${invite.crawlName}”.`
+  }
+  if (pendingInvites.value.length > 1) {
+    return `You have ${pendingInvites.value.length} pending pub crawl invitations waiting for a response.`
+  }
+  if (activeCrawl.value?.role === 'member' && activeCrawl.value.invitedBy) {
+    const inviter = activeCrawl.value.invitedBy
+    return `Shared crawl invited by ${inviter.displayName} (@${inviter.username}). You can view it, but only the creator can edit.`
+  }
+  return 'Your active crawl, invites, and shared lists.'
+})
+
+const activeSectionTitle = computed(() => {
+  if (activeCrawl.value?.role === 'member') return 'Shared with you'
+  return 'Current active crawl'
+})
+
+function inviteIdForNotification(note: { type?: string; crawlId?: string | null; link?: string | null }) {
+  if (note?.type !== 'crawl_invite') return null
+  const fromLink = typeof note.link === 'string'
+    ? note.link.match(/[?&]invite=([^&]+)/)?.[1]
+    : null
+  if (fromLink && pendingInvites.value.some((invite) => invite.id === fromLink)) {
+    return fromLink
+  }
+  if (note.crawlId) {
+    const match = pendingInvites.value.find((invite) => invite.crawlId === note.crawlId)
+    return match?.id || null
+  }
+  return null
+}
+
+function isOwnerCrawl(crawl: CrawlCard) {
+  return crawl.role === 'owner' && crawl.canEdit === true
+}
+
 async function loadDashboard() {
   loading.value = true
   errorMessage.value = ''
@@ -271,6 +353,11 @@ async function loadDashboard() {
     notifications.value = data.notifications || []
     unreadNotificationCount.value = data.unreadNotificationCount || 0
     loaded.value = true
+
+    const focusInvite = typeof route.query.invite === 'string' ? route.query.invite : ''
+    if (focusInvite && pendingInvites.value.some((invite) => invite.id === focusInvite)) {
+      // Keep invite highlighted via section at top; no extra action needed
+    }
   } catch (err: any) {
     errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not load pub crawls'
   } finally {
@@ -279,6 +366,7 @@ async function loadDashboard() {
 }
 
 async function respondInvite(memberId: string, action: 'accept' | 'decline') {
+  if (!memberId) return
   respondingId.value = memberId
   errorMessage.value = ''
   try {
@@ -292,7 +380,7 @@ async function respondInvite(memberId: string, action: 'accept' | 'decline') {
 }
 
 async function toggleComplete(crawl: CrawlCard, completed: boolean) {
-  if (!crawl.canEdit) return
+  if (!isOwnerCrawl(crawl)) return
   try {
     await useAuthFetch(`/api/crawls/${crawl.id}`, {
       method: 'PUT',
@@ -305,7 +393,7 @@ async function toggleComplete(crawl: CrawlCard, completed: boolean) {
 }
 
 function openInvite(crawl: CrawlCard) {
-  if (!crawl.canEdit) return
+  if (!isOwnerCrawl(crawl)) return
   inviteCrawl.value = crawl
   inviteQuery.value = ''
   inviteResults.value = []

--- a/server/api/crawls/[id]/members.ts
+++ b/server/api/crawls/[id]/members.ts
@@ -101,9 +101,9 @@ export default defineEventHandler(async (event) => {
     await createNotification({
       userId: invitee.userId,
       type: 'crawl_invite',
-      title: `${inviterProfile.username} invited you to a pub crawl`,
-      body: `Join “${crawl.name}” on UK Pubs.`,
-      link: '/pub-crawls',
+      title: `${inviterProfile.displayName} invited you to a pub crawl`,
+      body: `Join “${crawl.name}” on UK Pubs. Invited by @${inviterProfile.username}.`,
+      link: `/pub-crawls?invite=${member.id}`,
       crawlId: crawl.id,
     })
 

--- a/server/api/crawls/dashboard.get.ts
+++ b/server/api/crawls/dashboard.get.ts
@@ -102,17 +102,46 @@ export default defineEventHandler(async (event) => {
     return rows
   }
 
-  function withMeta(crawl: typeof owned[number], role: 'owner' | 'member') {
+  function withMeta(
+    crawl: typeof owned[number],
+    role: 'owner' | 'member',
+    extras?: {
+      invitedByUserId?: string | null
+    },
+  ) {
     const dto = serializeCrawl(crawl, { canEdit: role === 'owner', role })
+    const ownerProfile = profiles.get(crawl.userId)
+    const inviterId = extras?.invitedByUserId || null
+    const inviterProfile = inviterId ? profiles.get(inviterId) : null
     return {
       ...dto,
       members: memberDtos(crawl),
       acceptedMemberCount: (crawl.members || []).filter((m) => m.status === 'accepted').length,
+      owner: {
+        userId: crawl.userId,
+        username: ownerProfile?.username || 'owner',
+        displayName: ownerProfile?.displayName || 'Owner',
+      },
+      invitedBy: inviterProfile
+        ? {
+            userId: inviterId!,
+            username: inviterProfile.username,
+            displayName: inviterProfile.displayName,
+          }
+        : role === 'member'
+          ? {
+              userId: crawl.userId,
+              username: ownerProfile?.username || 'owner',
+              displayName: ownerProfile?.displayName || 'Owner',
+            }
+          : null,
     }
   }
 
   const ownedDtos = owned.map((c) => withMeta(c, 'owner'))
-  const sharedDtos = sharedCrawls.map((c) => withMeta(c, 'member'))
+  const sharedDtos = memberships.map((m) =>
+    withMeta(m.crawl, 'member', { invitedByUserId: m.invitedBy }),
+  )
 
   const activeOwned = ownedDtos.find((c) => !isCrawlCompleted(c))
   const activeShared = sharedDtos.find((c) => !isCrawlCompleted(c))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves the Pub Crawls dashboard for invitees so pending invitations are obvious, Accept/Decline is easy to find, and owner-only actions stay hidden from members.

## Changes

### For pending invitees
- Top amber banner: **“You have been invited by [name] (@username) to join …”**
- Clear **Accept invitation** / **Decline** buttons on the invite card
- Same Accept/Decline on matching `crawl_invite` notifications
- Subtitle reflects the invitation instead of only “Signed in as …”

### After accepting (shared crawl)
- Section titled **Shared with you**
- Card badge **Invited** (not Creator)
- Copy: **Invited by Name (@username)**
- Only **View on map** — no Invite / Mark complete / Delete

### Permissions
- Owner actions require `role === 'owner'` **and** `canEdit === true`
- Map crawl editor `canEditActiveCrawl` is fail-closed the same way

## Note on what you saw earlier

The screen with **Invite / Mark complete** and `@johannes… · pending` under “Who’s on this crawl” is the **creator** dashboard (John). After this lands, log in as Johannes and you should see the invitation banner with Accept at the top of Pub Crawls.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f115d295-b0d1-4947-b408-4e43bc3859e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f115d295-b0d1-4947-b408-4e43bc3859e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

