### PR TITLE
Add private chat for each pub crawl

### DIFF
--- a/components/crawl/CrawlChat.vue
+++ b/components/crawl/CrawlChat.vue
@@ -1,11 +1,25 @@
 <template>
   <div class="flex h-full min-h-[22rem] flex-col">
     <div class="border-b border-gray-200 px-1 pb-3 dark:border-gray-800">
-      <h3 class="text-base font-semibold text-gray-900 dark:text-white">
-        {{ crawlName }} chat
-      </h3>
+      <div class="flex flex-wrap items-center justify-between gap-2">
+        <h3 class="text-base font-semibold text-gray-900 dark:text-white">
+          {{ crawlName }} chat
+        </h3>
+        <span
+          class="inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide"
+          :class="realtimeConnected
+            ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-200'
+            : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300'"
+        >
+          <span
+            class="h-1.5 w-1.5 rounded-full"
+            :class="realtimeConnected ? 'bg-emerald-500' : 'bg-gray-400'"
+          />
+          {{ realtimeConnected ? 'Live' : 'Connecting' }}
+        </span>
+      </div>
       <p class="mt-0.5 text-xs text-gray-500">
-        Only the crawl creator and accepted members can see this conversation.
+        Only the crawl creator and accepted members can see this conversation. Messages update in real time.
       </p>
     </div>
 
@@ -79,13 +93,18 @@ const props = defineProps<{
   active?: boolean
 }>()
 
+const { $supabase } = useNuxtApp()
+
 const messages = ref<ChatMessage[]>([])
 const draft = ref('')
 const loading = ref(false)
 const sending = ref(false)
 const errorMessage = ref('')
+const realtimeConnected = ref(false)
 const listEl = ref<HTMLElement | null>(null)
-let pollTimer: ReturnType<typeof setInterval> | null = null
+
+let channel: ReturnType<typeof $supabase.channel> | null = null
+let fallbackPollTimer: ReturnType<typeof setInterval> | null = null
 
 function formatTime(iso: string) {
   try {
@@ -107,36 +126,53 @@ function scrollToBottom() {
   })
 }
 
+function appendMessage(message: ChatMessage) {
+  if (!message?.id) return
+  if (messages.value.some((m) => m.id === message.id)) return
+  messages.value = [...messages.value, message]
+  scrollToBottom()
+}
+
 async function loadMessages(options?: { silent?: boolean }) {
   if (!props.crawlId) return
   if (!options?.silent) loading.value = true
-  errorMessage.value = ''
+  if (!options?.silent) errorMessage.value = ''
   try {
-    const after = messages.value.length
+    const after = options?.silent && messages.value.length
       ? messages.value[messages.value.length - 1].createdAt
       : null
     const data = await useAuthFetch<{ messages: ChatMessage[] }>(
       `/api/crawls/${props.crawlId}/messages`,
       {
-        params: after && options?.silent ? { after } : {},
+        params: after ? { after } : {},
       },
     )
     const incoming = data.messages || []
     if (!options?.silent || !after) {
       messages.value = incoming
+      scrollToBottom()
     } else if (incoming.length) {
-      const seen = new Set(messages.value.map((m) => m.id))
-      const fresh = incoming.filter((m) => !seen.has(m.id))
-      if (fresh.length) {
-        messages.value = [...messages.value, ...fresh]
-        scrollToBottom()
-      }
+      for (const message of incoming) appendMessage(message)
     }
-    if (!options?.silent) scrollToBottom()
   } catch (err: any) {
-    errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not load chat'
+    if (!options?.silent) {
+      errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not load chat'
+    }
   } finally {
     loading.value = false
+  }
+}
+
+async function broadcastMessage(message: ChatMessage) {
+  if (!channel) return
+  try {
+    await channel.send({
+      type: 'broadcast',
+      event: 'chat_message',
+      payload: message,
+    })
+  } catch (err) {
+    console.warn('Could not broadcast chat message', err)
   }
 }
 
@@ -151,10 +187,8 @@ async function sendMessage() {
       body: { body },
     })
     draft.value = ''
-    if (!messages.value.some((m) => m.id === created.id)) {
-      messages.value = [...messages.value, created]
-    }
-    scrollToBottom()
+    appendMessage(created)
+    await broadcastMessage(created)
   } catch (err: any) {
     errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not send message'
   } finally {
@@ -162,34 +196,68 @@ async function sendMessage() {
   }
 }
 
-function startPolling() {
-  stopPolling()
-  pollTimer = setInterval(() => {
-    void loadMessages({ silent: true })
-  }, 4000)
+function stopFallbackPoll() {
+  if (fallbackPollTimer) {
+    clearInterval(fallbackPollTimer)
+    fallbackPollTimer = null
+  }
 }
 
-function stopPolling() {
-  if (pollTimer) {
-    clearInterval(pollTimer)
-    pollTimer = null
+function startFallbackPoll() {
+  stopFallbackPoll()
+  // Safety net if a broadcast is missed
+  fallbackPollTimer = setInterval(() => {
+    void loadMessages({ silent: true })
+  }, 12000)
+}
+
+async function stopRealtime() {
+  stopFallbackPoll()
+  realtimeConnected.value = false
+  if (channel && $supabase) {
+    try {
+      await $supabase.removeChannel(channel)
+    } catch {
+      /* ignore */
+    }
   }
+  channel = null
+}
+
+async function startRealtime(crawlId: string) {
+  await stopRealtime()
+  if (!$supabase?.channel || !crawlId) return
+
+  channel = $supabase
+    .channel(`ukpubs-crawl-chat:${crawlId}`, {
+      config: { broadcast: { self: false } },
+    })
+    .on('broadcast', { event: 'chat_message' }, ({ payload }) => {
+      const message = payload as ChatMessage
+      if (message?.crawlId && message.crawlId !== crawlId) return
+      appendMessage(message)
+    })
+    .subscribe((status: string) => {
+      realtimeConnected.value = status === 'SUBSCRIBED'
+    })
+
+  startFallbackPoll()
 }
 
 watch(
   () => [props.crawlId, props.active] as const,
   async ([id, active]) => {
-    stopPolling()
+    await stopRealtime()
     messages.value = []
     draft.value = ''
     if (!id || active === false) return
     await loadMessages()
-    startPolling()
+    await startRealtime(id)
   },
   { immediate: true },
 )
 
 onBeforeUnmount(() => {
-  stopPolling()
+  void stopRealtime()
 })
 </script>

--- a/components/crawl/CrawlChat.vue
+++ b/components/crawl/CrawlChat.vue
@@ -1,0 +1,195 @@
+<template>
+  <div class="flex h-full min-h-[22rem] flex-col">
+    <div class="border-b border-gray-200 px-1 pb-3 dark:border-gray-800">
+      <h3 class="text-base font-semibold text-gray-900 dark:text-white">
+        {{ crawlName }} chat
+      </h3>
+      <p class="mt-0.5 text-xs text-gray-500">
+        Only the crawl creator and accepted members can see this conversation.
+      </p>
+    </div>
+
+    <div
+      ref="listEl"
+      class="min-h-0 flex-1 space-y-3 overflow-y-auto py-3 pr-1"
+    >
+      <div v-if="loading && !messages.length" class="text-sm text-gray-500">
+        Loading chat…
+      </div>
+      <p v-else-if="!messages.length" class="text-sm text-gray-500">
+        No messages yet. Say hi to your crawl group.
+      </p>
+      <div
+        v-for="message in messages"
+        :key="message.id"
+        class="rounded-lg px-3 py-2 text-sm"
+        :class="message.userId === currentUserId
+          ? 'ml-8 bg-amber-50 text-amber-950 dark:bg-amber-950/40 dark:text-amber-100'
+          : 'mr-8 bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100'"
+      >
+        <div class="mb-1 flex flex-wrap items-baseline justify-between gap-2 text-[11px]">
+          <span class="font-semibold">
+            {{ message.displayName }}
+            <span class="font-normal text-gray-500 dark:text-gray-400">@{{ message.username }}</span>
+          </span>
+          <time class="text-gray-500 dark:text-gray-400" :datetime="message.createdAt">
+            {{ formatTime(message.createdAt) }}
+          </time>
+        </div>
+        <p class="whitespace-pre-wrap break-words leading-5">{{ message.body }}</p>
+      </div>
+      <p v-if="errorMessage" class="text-sm text-red-600 dark:text-red-400">{{ errorMessage }}</p>
+    </div>
+
+    <form class="mt-auto flex gap-2 border-t border-gray-200 pt-3 dark:border-gray-800" @submit.prevent="sendMessage">
+      <UInput
+        v-model="draft"
+        class="flex-1"
+        maxlength="2000"
+        autocomplete="off"
+        placeholder="Write a message…"
+        :disabled="sending"
+      />
+      <UButton
+        type="submit"
+        color="amber"
+        :loading="sending"
+        :disabled="!draft.trim()"
+        label="Send"
+      />
+    </form>
+  </div>
+</template>
+
+<script setup lang="ts">
+type ChatMessage = {
+  id: string
+  crawlId: string
+  userId: string
+  body: string
+  createdAt: string
+  username: string
+  displayName: string
+}
+
+const props = defineProps<{
+  crawlId: string
+  crawlName: string
+  currentUserId: string
+  active?: boolean
+}>()
+
+const messages = ref<ChatMessage[]>([])
+const draft = ref('')
+const loading = ref(false)
+const sending = ref(false)
+const errorMessage = ref('')
+const listEl = ref<HTMLElement | null>(null)
+let pollTimer: ReturnType<typeof setInterval> | null = null
+
+function formatTime(iso: string) {
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      day: 'numeric',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  } catch {
+    return iso
+  }
+}
+
+function scrollToBottom() {
+  nextTick(() => {
+    const el = listEl.value
+    if (el) el.scrollTop = el.scrollHeight
+  })
+}
+
+async function loadMessages(options?: { silent?: boolean }) {
+  if (!props.crawlId) return
+  if (!options?.silent) loading.value = true
+  errorMessage.value = ''
+  try {
+    const after = messages.value.length
+      ? messages.value[messages.value.length - 1].createdAt
+      : null
+    const data = await useAuthFetch<{ messages: ChatMessage[] }>(
+      `/api/crawls/${props.crawlId}/messages`,
+      {
+        params: after && options?.silent ? { after } : {},
+      },
+    )
+    const incoming = data.messages || []
+    if (!options?.silent || !after) {
+      messages.value = incoming
+    } else if (incoming.length) {
+      const seen = new Set(messages.value.map((m) => m.id))
+      const fresh = incoming.filter((m) => !seen.has(m.id))
+      if (fresh.length) {
+        messages.value = [...messages.value, ...fresh]
+        scrollToBottom()
+      }
+    }
+    if (!options?.silent) scrollToBottom()
+  } catch (err: any) {
+    errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not load chat'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function sendMessage() {
+  const body = draft.value.trim()
+  if (!body || sending.value) return
+  sending.value = true
+  errorMessage.value = ''
+  try {
+    const created = await useAuthFetch<ChatMessage>(`/api/crawls/${props.crawlId}/messages`, {
+      method: 'POST',
+      body: { body },
+    })
+    draft.value = ''
+    if (!messages.value.some((m) => m.id === created.id)) {
+      messages.value = [...messages.value, created]
+    }
+    scrollToBottom()
+  } catch (err: any) {
+    errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not send message'
+  } finally {
+    sending.value = false
+  }
+}
+
+function startPolling() {
+  stopPolling()
+  pollTimer = setInterval(() => {
+    void loadMessages({ silent: true })
+  }, 4000)
+}
+
+function stopPolling() {
+  if (pollTimer) {
+    clearInterval(pollTimer)
+    pollTimer = null
+  }
+}
+
+watch(
+  () => [props.crawlId, props.active] as const,
+  async ([id, active]) => {
+    stopPolling()
+    messages.value = []
+    draft.value = ''
+    if (!id || active === false) return
+    await loadMessages()
+    startPolling()
+  },
+  { immediate: true },
+)
+
+onBeforeUnmount(() => {
+  stopPolling()
+})
+</script>

--- a/components/crawl/DashboardCard.vue
+++ b/components/crawl/DashboardCard.vue
@@ -11,11 +11,7 @@
                 ? 'bg-amber-100 text-amber-900 dark:bg-amber-900 dark:text-amber-100'
                 : 'bg-sky-100 text-sky-900 dark:bg-sky-900 dark:text-sky-100'"
             >
-<<<<<<< HEAD
-              {{ isOwner ? 'Creator' : (crawl.role === 'member' ? 'Invited' : 'View only') }}
-=======
               {{ isOwner ? 'Creator' : 'Invited' }}
->>>>>>> origin/master
             </span>
             <span
               v-if="crawl.completedAt"
@@ -38,7 +34,6 @@
         <div class="flex flex-wrap gap-2">
           <UButton size="xs" color="amber" variant="soft" to="/map" label="View on map" />
           <UButton
-<<<<<<< HEAD
             size="xs"
             color="sky"
             variant="soft"
@@ -47,8 +42,6 @@
             @click="chatOpen = true"
           />
           <UButton
-=======
->>>>>>> origin/master
             v-if="isOwner"
             size="xs"
             color="gray"
@@ -162,13 +155,7 @@ const emit = defineEmits<{
   deleted: []
 }>()
 
-<<<<<<< HEAD
-const isOwner = computed(() =>
-  props.crawl.canEdit === true && (props.crawl.role == null || props.crawl.role === 'owner'),
-)
-=======
 const isOwner = computed(() => props.crawl.role === 'owner' && props.crawl.canEdit === true)
->>>>>>> origin/master
 
 const invitedByLabel = computed(() => {
   const inviter = props.crawl.invitedBy || props.crawl.owner
@@ -179,10 +166,7 @@ const invitedByLabel = computed(() => {
   return inviter.displayName || (inviter.username ? `@${inviter.username}` : '')
 })
 
-<<<<<<< HEAD
 const chatOpen = ref(false)
-=======
->>>>>>> origin/master
 const deleting = ref(false)
 
 async function deleteCrawl() {

--- a/components/crawl/DashboardCard.vue
+++ b/components/crawl/DashboardCard.vue
@@ -7,11 +7,11 @@
             <h3 class="text-base font-semibold text-gray-900 dark:text-white">{{ crawl.name }}</h3>
             <span
               class="rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide"
-              :class="crawl.canEdit
+              :class="isOwner
                 ? 'bg-amber-100 text-amber-900 dark:bg-amber-900 dark:text-amber-100'
                 : 'bg-sky-100 text-sky-900 dark:bg-sky-900 dark:text-sky-100'"
             >
-              {{ crawl.canEdit ? 'Creator' : 'View only' }}
+              {{ isOwner ? 'Creator' : (crawl.role === 'member' ? 'Invited' : 'View only') }}
             </span>
             <span
               v-if="crawl.completedAt"
@@ -21,6 +21,10 @@
             </span>
           </div>
           <p class="mt-1 text-sm text-gray-500">
+            <template v-if="!isOwner && invitedByLabel">
+              Invited by {{ invitedByLabel }}
+              ·
+            </template>
             {{ crawl.stopCount }} stop{{ crawl.stopCount === 1 ? '' : 's' }}
             <template v-if="crawl.stopCount">
               · progress {{ Math.min(crawl.currentStopIndex + 1, crawl.stopCount) }}/{{ crawl.stopCount }}
@@ -30,7 +34,15 @@
         <div class="flex flex-wrap gap-2">
           <UButton size="xs" color="amber" variant="soft" to="/map" label="View on map" />
           <UButton
-            v-if="crawl.canEdit"
+            size="xs"
+            color="sky"
+            variant="soft"
+            icon="i-heroicons-chat-bubble-left-right-20-solid"
+            label="Chat"
+            @click="chatOpen = true"
+          />
+          <UButton
+            v-if="isOwner"
             size="xs"
             color="gray"
             variant="soft"
@@ -38,7 +50,7 @@
             @click="$emit('invite')"
           />
           <UButton
-            v-if="crawl.canEdit && !crawl.completedAt"
+            v-if="isOwner && !crawl.completedAt"
             size="xs"
             color="emerald"
             variant="soft"
@@ -46,7 +58,7 @@
             @click="$emit('complete')"
           />
           <UButton
-            v-if="crawl.canEdit && crawl.completedAt"
+            v-if="isOwner && crawl.completedAt"
             size="xs"
             color="gray"
             variant="soft"
@@ -54,7 +66,7 @@
             @click="$emit('reopen')"
           />
           <UButton
-            v-if="crawl.canEdit"
+            v-if="isOwner"
             size="xs"
             color="red"
             variant="ghost"
@@ -86,6 +98,29 @@
         <p v-else class="text-xs text-gray-500">Just you so far.</p>
       </div>
     </div>
+
+    <USlideover v-model="chatOpen">
+      <div class="flex h-full flex-col p-4">
+        <div class="mb-2 flex justify-end">
+          <UButton
+            color="gray"
+            variant="ghost"
+            icon="i-heroicons-x-mark-20-solid"
+            aria-label="Close chat"
+            @click="chatOpen = false"
+          />
+        </div>
+        <CrawlChat
+          v-if="currentUserId"
+          class="min-h-0 flex-1"
+          :crawl-id="crawl.id"
+          :crawl-name="crawl.name"
+          :current-user-id="currentUserId"
+          :active="chatOpen"
+        />
+        <p v-else class="text-sm text-gray-500">Sign in to use crawl chat.</p>
+      </div>
+    </USlideover>
   </UCard>
 </template>
 
@@ -98,6 +133,9 @@ const props = defineProps<{
     currentStopIndex: number
     completedAt: string | null
     canEdit: boolean
+    role?: 'owner' | 'member'
+    invitedBy?: { userId: string; username: string; displayName: string } | null
+    owner?: { userId: string; username: string; displayName: string } | null
     members?: Array<{
       userId: string
       username: string
@@ -106,6 +144,7 @@ const props = defineProps<{
       role: string
     }>
   }
+  currentUserId?: string | null
   accent?: 'emerald' | 'gray'
 }>()
 
@@ -116,10 +155,24 @@ const emit = defineEmits<{
   deleted: []
 }>()
 
+const isOwner = computed(() =>
+  props.crawl.canEdit === true && (props.crawl.role == null || props.crawl.role === 'owner'),
+)
+
+const invitedByLabel = computed(() => {
+  const inviter = props.crawl.invitedBy || props.crawl.owner
+  if (!inviter) return ''
+  if (inviter.displayName && inviter.username) {
+    return `${inviter.displayName} (@${inviter.username})`
+  }
+  return inviter.displayName || (inviter.username ? `@${inviter.username}` : '')
+})
+
+const chatOpen = ref(false)
 const deleting = ref(false)
 
 async function deleteCrawl() {
-  if (!props.crawl.canEdit) return
+  if (!isOwner.value) return
   if (!confirm(`Delete “${props.crawl.name}”? This cannot be undone.`)) return
   deleting.value = true
   try {

--- a/components/map/PubCrawlBuilder.vue
+++ b/components/map/PubCrawlBuilder.vue
@@ -141,6 +141,24 @@
           variant="soft"
           description="View only — you were invited to this crawl. Only the creator can edit or delete it."
         />
+        <div class="flex flex-wrap gap-2">
+          <UButton
+            size="xs"
+            color="sky"
+            variant="soft"
+            icon="i-heroicons-chat-bubble-left-right-20-solid"
+            :label="chatOpen ? 'Hide chat' : 'Crawl chat'"
+            @click="chatOpen = !chatOpen"
+          />
+        </div>
+        <CrawlChat
+          v-if="chatOpen && chatUserId"
+          class="rounded-lg border border-gray-200 p-3 dark:border-gray-800"
+          :crawl-id="activeCrawl.id"
+          :crawl-name="activeCrawl.name"
+          :current-user-id="chatUserId"
+          :active="chatOpen"
+        />
         <section v-if="canEditActiveCrawl" class="space-y-2">
           <h3 class="text-sm font-semibold text-gray-900 dark:text-white">Add a pub</h3>
           <p class="text-xs text-gray-500">
@@ -390,6 +408,17 @@ const {
   canEditActiveCrawl,
   initialize,
 } = usePubCrawl()
+
+const { user } = useAuth()
+const chatOpen = ref(false)
+const chatUserId = computed(() => (user.value as { id?: string } | null)?.id || '')
+
+watch(
+  () => activeCrawl.value?.id,
+  () => {
+    chatOpen.value = false
+  },
+)
 
 type VenueSearchHit = {
   id: number

--- a/pages/pub-crawls/index.vue
+++ b/pages/pub-crawls/index.vue
@@ -107,6 +107,7 @@
         <CrawlDashboardCard
           v-if="activeCrawl"
           :crawl="activeCrawl"
+          :current-user-id="profile?.userId"
           accent="emerald"
           @invite="openInvite(activeCrawl)"
           @complete="toggleComplete(activeCrawl, true)"
@@ -128,6 +129,7 @@
             v-for="crawl in otherCrawls"
             :key="crawl.id"
             :crawl="crawl"
+            :current-user-id="profile?.userId"
             @invite="openInvite(crawl)"
             @complete="toggleComplete(crawl, true)"
             @reopen="toggleComplete(crawl, false)"
@@ -145,6 +147,7 @@
             v-for="crawl in completedCrawls"
             :key="crawl.id"
             :crawl="crawl"
+            :current-user-id="profile?.userId"
             accent="gray"
             @invite="openInvite(crawl)"
             @complete="toggleComplete(crawl, true)"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -218,6 +218,7 @@ model UkpubsCrawl {
   stops            UkpubsCrawlStop[]
   members          UkpubsCrawlMember[]
   notifications    UkpubsNotification[]
+  messages         UkpubsCrawlMessage[]
 
   @@index([userId])
   @@index([userId, updatedAt(sort: Desc)])
@@ -286,4 +287,18 @@ model UkpubsNotification {
 
   @@index([userId, createdAt(sort: Desc)])
   @@map("ukpubs_notifications")
+}
+
+/// Chat messages within a pub crawl (table: ukpubs_crawl_messages)
+model UkpubsCrawlMessage {
+  id        String      @id @default(uuid())
+  crawlId   String      @map("crawl_id")
+  userId    String      @map("user_id")
+  body      String
+  createdAt DateTime    @default(now()) @map("created_at")
+  crawl     UkpubsCrawl @relation(fields: [crawlId], references: [id], onDelete: Cascade)
+
+  @@index([crawlId, createdAt])
+  @@index([userId])
+  @@map("ukpubs_crawl_messages")
 }

--- a/scripts/sql/ukpubs_crawl_messages.sql
+++ b/scripts/sql/ukpubs_crawl_messages.sql
@@ -1,0 +1,35 @@
+-- UK Pubs: per-crawl chat messages (creator + accepted members only)
+-- Run in Supabase SQL editor after ukpubs_crawls / ukpubs_crawl_members exist.
+-- Safe to re-run.
+-- =============================================================================
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS public.ukpubs_crawl_messages (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    crawl_id UUID NOT NULL,
+    user_id TEXT NOT NULL,
+    body TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT ukpubs_crawl_messages_body_not_blank
+        CHECK (char_length(trim(body)) > 0),
+    CONSTRAINT ukpubs_crawl_messages_body_len
+        CHECK (char_length(body) <= 2000)
+);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'ukpubs_crawl_messages_crawl_id_fkey'
+    ) THEN
+        ALTER TABLE public.ukpubs_crawl_messages
+            ADD CONSTRAINT ukpubs_crawl_messages_crawl_id_fkey
+            FOREIGN KEY (crawl_id) REFERENCES public.ukpubs_crawls (id) ON DELETE CASCADE;
+    END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS ukpubs_crawl_messages_crawl_created_idx
+    ON public.ukpubs_crawl_messages (crawl_id, created_at ASC);
+
+CREATE INDEX IF NOT EXISTS ukpubs_crawl_messages_user_idx
+    ON public.ukpubs_crawl_messages (user_id);

--- a/scripts/sql/ukpubs_crawl_messages.sql
+++ b/scripts/sql/ukpubs_crawl_messages.sql
@@ -33,3 +33,28 @@ CREATE INDEX IF NOT EXISTS ukpubs_crawl_messages_crawl_created_idx
 
 CREATE INDEX IF NOT EXISTS ukpubs_crawl_messages_user_idx
     ON public.ukpubs_crawl_messages (user_id);
+
+-- Optional: enable Supabase Realtime postgres changes on this table
+-- (the app uses Realtime broadcast for live chat; this helps if you add DB listeners later)
+DO $$
+BEGIN
+    ALTER TABLE public.ukpubs_crawl_messages REPLICA IDENTITY FULL;
+EXCEPTION
+    WHEN undefined_table THEN
+        NULL;
+END $$;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_publication WHERE pubname = 'supabase_realtime') THEN
+        IF NOT EXISTS (
+            SELECT 1
+            FROM pg_publication_tables
+            WHERE pubname = 'supabase_realtime'
+              AND schemaname = 'public'
+              AND tablename = 'ukpubs_crawl_messages'
+        ) THEN
+            ALTER PUBLICATION supabase_realtime ADD TABLE public.ukpubs_crawl_messages;
+        END IF;
+    END IF;
+END $$;

--- a/server/api/crawls/[id]/messages.ts
+++ b/server/api/crawls/[id]/messages.ts
@@ -1,0 +1,90 @@
+import { prisma } from '../../../utils/prisma'
+import { requireAuth } from '../../../utils/require-auth'
+import { getCrawlAccess } from '../../../utils/crawls'
+import { ensureUkpubsProfile, getProfilesByUserIds } from '../../../utils/crawl-profiles'
+
+const MAX_BODY_LENGTH = 2000
+const DEFAULT_LIMIT = 100
+
+function serializeMessage(
+  row: { id: string; crawlId: string; userId: string; body: string; createdAt: Date },
+  profile?: { username: string; displayName: string } | null,
+) {
+  return {
+    id: row.id,
+    crawlId: row.crawlId,
+    userId: row.userId,
+    body: row.body,
+    createdAt: row.createdAt.toISOString(),
+    username: profile?.username || 'user',
+    displayName: profile?.displayName || 'User',
+  }
+}
+
+export default defineEventHandler(async (event) => {
+  const user = await requireAuth(event)
+  const crawlId = getRouterParam(event, 'id')
+  if (!crawlId) {
+    throw createError({ statusCode: 400, statusMessage: 'Crawl id is required' })
+  }
+
+  // Owner or accepted member only (pending invitees cannot chat yet)
+  await getCrawlAccess(crawlId, user.id)
+  await ensureUkpubsProfile(user)
+
+  if (event.method === 'GET') {
+    const query = getQuery(event)
+    const after = typeof query.after === 'string' && query.after ? query.after : null
+    const limitRaw = Number(query.limit)
+    const limit = Number.isFinite(limitRaw)
+      ? Math.min(Math.max(Math.floor(limitRaw), 1), 200)
+      : DEFAULT_LIMIT
+
+    const rows = await prisma.ukpubsCrawlMessage.findMany({
+      where: {
+        crawlId,
+        ...(after
+          ? {
+              createdAt: {
+                gt: new Date(after),
+              },
+            }
+          : {}),
+      },
+      orderBy: { createdAt: 'asc' },
+      take: limit,
+    })
+
+    const profiles = await getProfilesByUserIds([...new Set(rows.map((r) => r.userId))])
+    return {
+      messages: rows.map((row) => serializeMessage(row, profiles.get(row.userId))),
+    }
+  }
+
+  if (event.method === 'POST') {
+    const body = await readBody(event)
+    const text = String(body?.body || '').trim()
+    if (!text) {
+      throw createError({ statusCode: 400, statusMessage: 'Message cannot be empty' })
+    }
+    if (text.length > MAX_BODY_LENGTH) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: `Message must be ${MAX_BODY_LENGTH} characters or fewer`,
+      })
+    }
+
+    const created = await prisma.ukpubsCrawlMessage.create({
+      data: {
+        crawlId,
+        userId: user.id,
+        body: text,
+      },
+    })
+
+    const profile = await ensureUkpubsProfile(user)
+    return serializeMessage(created, profile)
+  }
+
+  throw createError({ statusCode: 405, statusMessage: 'Method not allowed' })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **private chat per pub crawl** for the crawl creator and accepted members only. Pending invitees cannot read or write until they accept.

Messages appear in **real time** via Supabase Realtime broadcast.

Merged with latest `master` (including invitee dashboard #35). `DashboardCard.vue` conflicts resolved: Chat button + slideover kept, Creator/Invited owner gating from master kept.

## Database

Run in Supabase SQL editor:

`scripts/sql/ukpubs_crawl_messages.sql`

Creates `ukpubs_crawl_messages` and optionally adds it to the `supabase_realtime` publication.

## API

`GET /api/crawls/:id/messages` — list messages (optional `?after=` for sync)  
`POST /api/crawls/:id/messages` — send `{ body }`

Access via `getCrawlAccess` (owner or **accepted** member).

## UI / realtime

- **Pub Crawls dashboard**: **Chat** button → slideover
- **Map crawl builder**: **Crawl chat** toggle
- Live badge when subscribed
- On send: persist via API, then **broadcast** to `ukpubs-crawl-chat:{crawlId}`
- Other members append instantly; light 12s poll as safety net

## Notes

- Please apply the SQL before using chat in production
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f115d295-b0d1-4947-b408-4e43bc3859e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f115d295-b0d1-4947-b408-4e43bc3859e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

