### PR TITLE
Fix Invalid or expired session on crawl chat

### DIFF
--- a/components/crawl/CrawlChat.vue
+++ b/components/crawl/CrawlChat.vue
@@ -156,7 +156,12 @@ async function loadMessages(options?: { silent?: boolean }) {
     }
   } catch (err: any) {
     if (!options?.silent) {
-      errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not load chat'
+      const status = err?.statusCode || err?.status || err?.data?.statusCode
+      if (status === 401) {
+        errorMessage.value = 'Your session expired. Please sign out and sign back in, then open chat again.'
+      } else {
+        errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not load chat'
+      }
     }
   } finally {
     loading.value = false
@@ -190,7 +195,12 @@ async function sendMessage() {
     appendMessage(created)
     await broadcastMessage(created)
   } catch (err: any) {
-    errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not send message'
+    const status = err?.statusCode || err?.status || err?.data?.statusCode
+    if (status === 401) {
+      errorMessage.value = 'Your session expired. Please sign out and sign back in, then try again.'
+    } else {
+      errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not send message'
+    }
   } finally {
     sending.value = false
   }

--- a/composables/useAuthFetch.ts
+++ b/composables/useAuthFetch.ts
@@ -1,20 +1,63 @@
-/** Authenticated $fetch wrapper using the current Supabase session token. */
+/** Authenticated $fetch wrapper using a fresh Supabase access token. */
 export async function useAuthFetch<T>(
   url: string,
   options: Parameters<typeof $fetch<T>>[1] = {},
 ): Promise<T> {
   const { $supabase } = useNuxtApp()
-  const { data } = await $supabase.auth.getSession()
-  const token = data.session?.access_token
-  if (!token) {
+
+  if (!$supabase?.auth) {
     throw createError({ statusCode: 401, statusMessage: 'You must be logged in' })
   }
 
-  return $fetch<T>(url, {
-    ...options,
-    headers: {
-      ...(options.headers as Record<string, string> | undefined),
-      Authorization: `Bearer ${token}`,
-    },
-  })
+  async function resolveAccessToken(forceRefresh = false): Promise<string> {
+    if (forceRefresh) {
+      const { data, error } = await $supabase.auth.refreshSession()
+      const token = data.session?.access_token
+      if (error || !token) {
+        throw createError({ statusCode: 401, statusMessage: 'You must be logged in' })
+      }
+      return token
+    }
+
+    const { data } = await $supabase.auth.getSession()
+    const session = data.session
+    if (!session?.access_token) {
+      throw createError({ statusCode: 401, statusMessage: 'You must be logged in' })
+    }
+
+    // getSession() can return a cached expired JWT — refresh when near expiry
+    const expiresAt = Number(session.expires_at || 0)
+    const now = Math.floor(Date.now() / 1000)
+    if (expiresAt > 0 && expiresAt - now < 90) {
+      const { data: refreshed, error } = await $supabase.auth.refreshSession()
+      if (!error && refreshed.session?.access_token) {
+        return refreshed.session.access_token
+      }
+    }
+
+    return session.access_token
+  }
+
+  function withAuthHeaders(token: string) {
+    return {
+      ...options,
+      headers: {
+        ...(options.headers as Record<string, string> | undefined),
+        Authorization: `Bearer ${token}`,
+      },
+    }
+  }
+
+  const token = await resolveAccessToken()
+
+  try {
+    return await $fetch<T>(url, withAuthHeaders(token))
+  } catch (err: any) {
+    const status = err?.statusCode || err?.status || err?.response?.status
+    if (status !== 401) throw err
+
+    // Retry once with a forced refresh (covers expired access tokens)
+    const freshToken = await resolveAccessToken(true)
+    return await $fetch<T>(url, withAuthHeaders(freshToken))
+  }
 }

--- a/composables/useAuthFetch.ts
+++ b/composables/useAuthFetch.ts
@@ -14,7 +14,15 @@ export async function useAuthFetch<T>(
       const { data, error } = await $supabase.auth.refreshSession()
       const token = data.session?.access_token
       if (error || !token) {
-        throw createError({ statusCode: 401, statusMessage: 'You must be logged in' })
+        try {
+          await $supabase.auth.signOut()
+        } catch {
+          /* ignore */
+        }
+        throw createError({
+          statusCode: 401,
+          statusMessage: 'Your session expired. Please sign in again.',
+        })
       }
       return token
     }
@@ -32,6 +40,18 @@ export async function useAuthFetch<T>(
       const { data: refreshed, error } = await $supabase.auth.refreshSession()
       if (!error && refreshed.session?.access_token) {
         return refreshed.session.access_token
+      }
+      // If refresh failed with an invalid refresh token, force re-login
+      if (error) {
+        try {
+          await $supabase.auth.signOut()
+        } catch {
+          /* ignore */
+        }
+        throw createError({
+          statusCode: 401,
+          statusMessage: 'Your session expired. Please sign in again.',
+        })
       }
     }
 

--- a/composables/usePubCrawl.ts
+++ b/composables/usePubCrawl.ts
@@ -24,22 +24,38 @@ export type CrawlSummary = {
   stops?: CrawlStop[]
 }
 
-const ACTIVE_CRAWL_KEY = 'ukpubs_active_crawl_id'
+const ACTIVE_CRAWL_KEY_PREFIX = 'ukpubs_active_crawl_id:'
+const LEGACY_ACTIVE_CRAWL_KEY = 'ukpubs_active_crawl_id'
 
-function rememberActiveCrawlId(id: string | null) {
+function storageKeyForUser(userId: string | null | undefined) {
+  if (!userId) return null
+  return `${ACTIVE_CRAWL_KEY_PREFIX}${userId}`
+}
+
+function rememberActiveCrawlId(id: string | null, userId?: string | null) {
   if (!import.meta.client) return
   try {
-    if (id) localStorage.setItem(ACTIVE_CRAWL_KEY, id)
-    else localStorage.removeItem(ACTIVE_CRAWL_KEY)
+    const key = storageKeyForUser(userId)
+    // Always clear the legacy global key so account-switching cannot leak crawls
+    localStorage.removeItem(LEGACY_ACTIVE_CRAWL_KEY)
+    if (!key) return
+    if (id) localStorage.setItem(key, id)
+    else localStorage.removeItem(key)
   } catch {
     /* ignore */
   }
 }
 
-function readRememberedCrawlId() {
+function readRememberedCrawlId(userId?: string | null) {
   if (!import.meta.client) return null
   try {
-    return localStorage.getItem(ACTIVE_CRAWL_KEY)
+    const key = storageKeyForUser(userId)
+    if (key) {
+      const scoped = localStorage.getItem(key)
+      if (scoped) return scoped
+    }
+    // One-time legacy fallback (pre user-scoped keys)
+    return localStorage.getItem(LEGACY_ACTIVE_CRAWL_KEY)
   } catch {
     return null
   }
@@ -54,7 +70,7 @@ function formatSavedTime(iso: string) {
 }
 
 export function usePubCrawl() {
-  const { isLoggedIn, initializeAuth } = useAuth()
+  const { isLoggedIn, initializeAuth, user } = useAuth()
 
   const crawls = useState<CrawlSummary[]>('ukpubs-crawls', () => [])
   const activeCrawl = useState<CrawlSummary | null>('ukpubs-active-crawl', () => null)
@@ -69,6 +85,38 @@ export function usePubCrawl() {
   const dirty = useState<boolean>('ukpubs-crawl-dirty', () => false)
   const lastSavedAt = useState<string>('ukpubs-crawl-saved-at', () => '')
   const initialized = useState<boolean>('ukpubs-crawl-initialized', () => false)
+  const boundUserId = useState<string | null>('ukpubs-crawl-bound-user', () => null)
+
+  const currentUserId = computed(() => (user.value as { id?: string } | null)?.id || null)
+
+  function resetCrawlState(options?: { clearRemembered?: boolean }) {
+    crawls.value = []
+    activeCrawl.value = null
+    stops.value = []
+    currentStopIndex.value = 0
+    draftName.value = ''
+    dirty.value = false
+    lastSavedAt.value = ''
+    errorMessage.value = ''
+    initialized.value = false
+    if (options?.clearRemembered) {
+      rememberActiveCrawlId(null, boundUserId.value || currentUserId.value)
+    }
+  }
+
+  // When switching accounts in the same browser, drop the previous user's crawl state
+  watch(
+    currentUserId,
+    (next, prev) => {
+      if (next === prev) return
+      if (prev && next !== prev) {
+        rememberActiveCrawlId(null, prev)
+        resetCrawlState()
+      }
+      boundUserId.value = next
+    },
+    { immediate: true },
+  )
 
   const legs = computed(() => buildCrawlLegs(stops.value))
 
@@ -113,7 +161,7 @@ export function usePubCrawl() {
     draftName.value = ''
     dirty.value = false
     lastSavedAt.value = ''
-    rememberActiveCrawlId(null)
+    rememberActiveCrawlId(null, currentUserId.value)
   }
 
   async function loadCrawls() {
@@ -139,27 +187,47 @@ export function usePubCrawl() {
       currentStopIndex.value = crawl.currentStopIndex || 0
       dirty.value = false
       lastSavedAt.value = formatSavedTime(crawl.updatedAt)
-      rememberActiveCrawlId(crawl.id)
+      rememberActiveCrawlId(crawl.id, currentUserId.value)
       return crawl
     } catch (err: any) {
+      const status = err?.statusCode || err?.status || err?.data?.statusCode
       errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not load crawl'
+      // Drop a remembered crawl this account cannot access (common after switching users)
+      if (status === 401 || status === 403 || status === 404) {
+        rememberActiveCrawlId(null, currentUserId.value)
+        if (activeCrawl.value?.id === id) {
+          activeCrawl.value = null
+          stops.value = []
+          currentStopIndex.value = 0
+          draftName.value = ''
+        }
+      }
       return null
     }
   }
 
   async function ensureActiveCrawl() {
     if (activeCrawl.value?.id) {
-      if (!stops.value.length && (activeCrawl.value.stopCount || 0) > 0) {
-        await loadCrawl(activeCrawl.value.id)
+      // Guard against stale in-memory crawl from another account
+      if (crawls.value.length && !crawls.value.some((c) => c.id === activeCrawl.value?.id)) {
+        clearActive()
+      } else {
+        if (!stops.value.length && (activeCrawl.value.stopCount || 0) > 0) {
+          await loadCrawl(activeCrawl.value.id)
+        }
+        return activeCrawl.value
       }
-      return activeCrawl.value
     }
 
     await loadCrawls()
 
-    const remembered = readRememberedCrawlId()
+    const remembered = readRememberedCrawlId(currentUserId.value)
     if (remembered && crawls.value.some((c) => c.id === remembered)) {
       return loadCrawl(remembered)
+    }
+    // Clear legacy/global remembered ids that this user cannot access
+    if (remembered && !crawls.value.some((c) => c.id === remembered)) {
+      rememberActiveCrawlId(null, currentUserId.value)
     }
 
     if (crawls.value.length >= 1) {
@@ -186,7 +254,7 @@ export function usePubCrawl() {
       currentStopIndex.value = 0
       dirty.value = false
       lastSavedAt.value = 'just now'
-      rememberActiveCrawlId(crawl.id)
+      rememberActiveCrawlId(crawl.id, currentUserId.value)
       await loadCrawls()
       return crawl
     } catch (err: any) {
@@ -209,7 +277,7 @@ export function usePubCrawl() {
         body: { name },
       })
       activeCrawl.value = { ...activeCrawl.value, name: crawl.name, canEdit: true, role: 'owner' }
-      rememberActiveCrawlId(crawl.id)
+      rememberActiveCrawlId(crawl.id, currentUserId.value)
       await loadCrawls()
       return crawl
     } catch (err: any) {
@@ -248,7 +316,7 @@ export function usePubCrawl() {
       currentStopIndex.value = crawl.currentStopIndex || 0
       dirty.value = false
       lastSavedAt.value = 'just now'
-      rememberActiveCrawlId(crawl.id)
+      rememberActiveCrawlId(crawl.id, currentUserId.value)
       await loadCrawls()
       return crawl
     } catch (err: any) {
@@ -464,25 +532,44 @@ export function usePubCrawl() {
 
   async function initialize() {
     await initializeAuth()
-    if (!isLoggedIn.value) {
-      crawls.value = []
+    if (!isLoggedIn.value || !currentUserId.value) {
+      resetCrawlState({ clearRemembered: false })
       clearActive()
       initialized.value = true
       return
     }
+
+    boundUserId.value = currentUserId.value
     await loadCrawls()
+
+    // Drop in-memory active crawl if it is not in this user's accessible list
+    if (activeCrawl.value && !crawls.value.some((c) => c.id === activeCrawl.value?.id)) {
+      clearActive()
+    }
+
     if (!activeCrawl.value) {
-      const remembered = readRememberedCrawlId()
+      const remembered = readRememberedCrawlId(currentUserId.value)
       if (remembered && crawls.value.some((c) => c.id === remembered)) {
         await loadCrawl(remembered)
-      } else if (crawls.value.length >= 1) {
-        // Always open the most recently updated list so the map has an active route
-        await loadCrawl(crawls.value[0].id)
+      } else {
+        if (remembered) rememberActiveCrawlId(null, currentUserId.value)
+        if (crawls.value.length >= 1) {
+          // Prefer first accessible crawl (owned + accepted shared)
+          await loadCrawl(crawls.value[0].id)
+        }
       }
     } else if (activeCrawl.value.id && !stops.value.length && activeCrawl.value.stopCount) {
       await loadCrawl(activeCrawl.value.id)
     }
     initialized.value = true
+  }
+
+  /** Remember + load a crawl after accepting an invite. */
+  async function openSharedCrawl(id: string) {
+    if (!id) return null
+    rememberActiveCrawlId(id, currentUserId.value)
+    await loadCrawls()
+    return loadCrawl(id)
   }
 
   return {
@@ -521,6 +608,7 @@ export function usePubCrawl() {
     setProgress,
     setProgressAndSave,
     reorderStops,
+    openSharedCrawl,
     initialize,
   }
 }

--- a/pages/pub-crawls/index.vue
+++ b/pages/pub-crawls/index.vue
@@ -245,6 +245,7 @@ definePageMeta({})
 
 const route = useRoute()
 const { isLoggedIn, initializeAuth } = useAuth()
+const { openSharedCrawl } = usePubCrawl()
 
 useSiteSeo({
   title: 'Pub Crawls',
@@ -362,7 +363,12 @@ async function loadDashboard() {
       // Keep invite highlighted via section at top; no extra action needed
     }
   } catch (err: any) {
-    errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not load pub crawls'
+    const status = err?.statusCode || err?.status || err?.data?.statusCode
+    if (status === 401) {
+      errorMessage.value = 'Your session expired. Please sign out and sign back in, then refresh this page.'
+    } else {
+      errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not load pub crawls'
+    }
   } finally {
     loading.value = false
   }
@@ -373,10 +379,25 @@ async function respondInvite(memberId: string, action: 'accept' | 'decline') {
   respondingId.value = memberId
   errorMessage.value = ''
   try {
-    await useAuthFetch(`/api/crawls/invites/${memberId}/${action}`, { method: 'POST' })
+    const result = await useAuthFetch<{
+      ok: boolean
+      status: string
+      crawl: { id: string; name: string }
+    }>(`/api/crawls/invites/${memberId}/${action}`, { method: 'POST' })
+
+    if (action === 'accept' && result?.crawl?.id) {
+      // Make this the invitee's active crawl so map/chat work after refresh
+      await openSharedCrawl(result.crawl.id)
+    }
+
     await loadDashboard()
   } catch (err: any) {
-    errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not respond to invite'
+    const status = err?.statusCode || err?.status || err?.data?.statusCode
+    if (status === 401) {
+      errorMessage.value = 'Your session expired. Please sign out and sign back in, then try again.'
+    } else {
+      errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not respond to invite'
+    }
   } finally {
     respondingId.value = null
   }

--- a/server/api/crawls/dashboard.get.ts
+++ b/server/api/crawls/dashboard.get.ts
@@ -145,10 +145,12 @@ export default defineEventHandler(async (event) => {
 
   const activeOwned = ownedDtos.find((c) => !isCrawlCompleted(c))
   const activeShared = sharedDtos.find((c) => !isCrawlCompleted(c))
+  // Prefer a shared (invited) crawl when the user has no owned incomplete crawl
   const activeCrawl = activeOwned || activeShared || null
 
+  // Sort shared crawls ahead of owned completed ones in "other" for invitees
   const completedCrawls = [...ownedDtos, ...sharedDtos].filter((c) => isCrawlCompleted(c))
-  const otherCrawls = [...ownedDtos, ...sharedDtos].filter((c) => {
+  const otherCrawls = [...sharedDtos, ...ownedDtos].filter((c) => {
     if (activeCrawl && c.id === activeCrawl.id) return false
     if (isCrawlCompleted(c)) return false
     return true

--- a/server/utils/require-auth.ts
+++ b/server/utils/require-auth.ts
@@ -11,15 +11,28 @@ export async function requireAuth(event: H3Event): Promise<User> {
   }
 
   const token = authHeader.slice('Bearer '.length).trim()
+  if (!token) {
+    throw createError({ statusCode: 401, statusMessage: 'Authentication required' })
+  }
+
   const supabaseUrl = config.public.supabase?.url
   const supabaseKey = config.public.supabase?.key
   if (!supabaseUrl || !supabaseKey) {
     throw createError({ statusCode: 503, statusMessage: 'Supabase is not configured' })
   }
 
-  const supabase = createClient(supabaseUrl, supabaseKey)
+  // Stateless server client — do not persist/refresh in serverless handlers
+  const supabase = createClient(supabaseUrl, supabaseKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+      detectSessionInUrl: false,
+    },
+  })
+
   const { data, error } = await supabase.auth.getUser(token)
   if (error || !data.user) {
+    console.warn('[requireAuth] getUser failed:', error?.message || 'no user')
     throw createError({ statusCode: 401, statusMessage: 'Invalid or expired session' })
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes **“Invalid or expired session/token”** for invitees after accepting a crawl invite (chat + dashboard/map), especially when switching accounts in the same browser.

## Root causes

1. **Expired Supabase access tokens** from `getSession()` without refresh
2. **Shared active-crawl localStorage key** — after testing as the creator, the invitee’s browser remembered the wrong crawl / stale auth state across account switches

## Fixes

- Refresh near-expiry tokens in `useAuthFetch`; retry once on 401; sign out cleanly if refresh token is invalid
- Scope remembered active crawl IDs **per user** (`ukpubs_active_crawl_id:{userId}`)
- Reset in-memory crawl state when the signed-in user changes
- After **Accept invitation**, open/remember that shared crawl for the invitee
- Clear remembered crawl on 401/403/404 load failures
- Clearer “session expired — sign in again” messaging

## Test plan

1. Log in as invitee (Johannes), accept invite
2. Refresh `/pub-crawls` — shared crawl should show under **Shared with you**
3. Open **Chat** and send a message
4. Open **View on map** — crawl route should load
5. Optional: switch creator ↔ invitee in same browser; each should only see their own accessible crawls

## Note

Please merge this before more invitee testing. If a session is already corrupted, **sign out and sign back in once**.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f115d295-b0d1-4947-b408-4e43bc3859e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f115d295-b0d1-4947-b408-4e43bc3859e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

