### PR TITLE
Map: invited crawls are view-only (no manage/edit/delete)

### DIFF
--- a/components/map/PubCrawlBuilder.vue
+++ b/components/map/PubCrawlBuilder.vue
@@ -572,10 +572,12 @@ async function onCreateCrawl() {
 }
 
 async function onSaveMeta() {
+  if (!canEditActiveCrawl.value) return
   await saveMeta()
 }
 
 async function onSaveCrawl() {
+  if (!canEditActiveCrawl.value) return
   await saveCrawl()
 }
 

--- a/components/map/PubCrawlBuilder.vue
+++ b/components/map/PubCrawlBuilder.vue
@@ -53,7 +53,7 @@
           </div>
         </div>
         <p class="text-xs text-gray-500">
-          You can keep as many crawl lists as you like. Tap one to open it on the map.
+          Tap a list to open it on the map. Invited lists are view-only — only the creator can edit or delete them.
         </p>
 
         <div v-if="loadingList && !crawls.length" class="text-sm text-gray-500">Loading…</div>
@@ -71,7 +71,17 @@
               class="min-w-0 flex-1 text-left"
               @click="selectCrawl(crawl.id)"
             >
-              <span class="block truncate font-medium text-gray-900 dark:text-white">{{ crawl.name }}</span>
+              <span class="block truncate font-medium text-gray-900 dark:text-white">
+                {{ crawl.name }}
+                <span
+                  v-if="isOwnedCrawl(crawl)"
+                  class="ml-1 text-[10px] font-semibold uppercase tracking-wide text-amber-700"
+                >Yours</span>
+                <span
+                  v-else
+                  class="ml-1 text-[10px] font-semibold uppercase tracking-wide text-sky-700"
+                >Invited</span>
+              </span>
               <span class="text-xs text-gray-500">
                 {{ crawl.stopCount }} stop{{ crawl.stopCount === 1 ? '' : 's' }}
                 <template v-if="crawl.stopCount">
@@ -81,6 +91,7 @@
               </span>
             </button>
             <UButton
+              v-if="isOwnedCrawl(crawl)"
               size="xs"
               color="red"
               variant="ghost"
@@ -94,7 +105,10 @@
         <p v-else class="text-sm text-gray-500">No saved crawls yet. Create one below.</p>
       </section>
 
-      <section class="space-y-2 rounded-md border border-gray-200 p-3 dark:border-gray-800">
+      <section
+        v-if="creatingNewList || !activeCrawl || canEditActiveCrawl"
+        class="space-y-2 rounded-md border border-gray-200 p-3 dark:border-gray-800"
+      >
         <label class="block text-sm font-medium text-gray-900 dark:text-white">
           {{ creatingNewList || !activeCrawl ? 'New crawl list name' : 'Rename active crawl' }}
         </label>
@@ -133,6 +147,15 @@
           @click="cancelNewList"
         />
       </section>
+      <div
+        v-else-if="activeCrawl"
+        class="rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-sm dark:border-sky-800 dark:bg-sky-950/30"
+      >
+        <p class="font-medium text-gray-900 dark:text-white">{{ activeCrawl.name }}</p>
+        <p class="text-xs text-sky-800 dark:text-sky-200">
+          Invited list — view only. You can’t rename, reorder, or delete this crawl.
+        </p>
+      </div>
 
       <template v-if="activeCrawl">
         <UAlert
@@ -557,8 +580,17 @@ async function onSaveCrawl() {
 }
 
 async function onDeleteCrawl(id: string) {
+  const crawl = crawls.value.find((c) => c.id === id)
+  if (!crawl || !isOwnedCrawl(crawl)) {
+    errorMessage.value = 'Only the crawl creator can delete this list.'
+    return
+  }
   if (!confirm('Delete this pub crawl? This cannot be undone.')) return
   await deleteCrawl(id)
+}
+
+function isOwnedCrawl(crawl: { canEdit?: boolean; role?: string | null }) {
+  return crawl.canEdit === true && crawl.role !== 'member'
 }
 
 function onStartFresh() {

--- a/composables/usePubCrawl.ts
+++ b/composables/usePubCrawl.ts
@@ -431,6 +431,7 @@ export function usePubCrawl() {
       errorMessage.value = 'Open or create a crawl first.'
       return false
     }
+    if (!ensureCanEdit()) return false
 
     if (!stops.value.length && (activeCrawl.value.stopCount || 0) > 0) {
       await loadCrawl(activeCrawl.value.id)
@@ -482,14 +483,15 @@ export function usePubCrawl() {
     markDirty()
   }
 
-  /** Persist progress immediately (manual Next / auto check-in). */
+  /** Persist progress immediately (manual Next / auto check-in). Creator only. */
   async function setProgressAndSave(index: number, options?: { fromArrival?: boolean }) {
-    if (!activeCrawl.value) return false
+    if (!activeCrawl.value || !ensureCanEdit()) return false
     if (index < 0 || index >= stops.value.length) return false
 
     // Only move forward on auto-arrival; allow manual jumps either way
     if (options?.fromArrival && index <= currentStopIndex.value) return false
 
+    const previousIndex = currentStopIndex.value
     currentStopIndex.value = index
     errorMessage.value = ''
     try {
@@ -506,6 +508,7 @@ export function usePubCrawl() {
       await loadCrawls()
       return true
     } catch (err: any) {
+      currentStopIndex.value = previousIndex
       errorMessage.value = err?.data?.statusMessage || err?.message || 'Could not update progress'
       markDirty()
       return false

--- a/pages/map/index.vue
+++ b/pages/map/index.vue
@@ -1273,6 +1273,8 @@ function stopCrawlGeolocation() {
 
 async function handleCrawlGeolocation(lat: number, lng: number) {
   if (!activeCrawl.value || stops.value.length < 1) return
+  // Only the crawl creator can advance progress (including auto check-in)
+  if (!canEditActiveCrawl.value) return
 
   const nearest = findNearestStopIndex(lat, lng, stops.value, CRAWL_ARRIVAL_RADIUS_METERS)
   if (!nearest) return

--- a/pages/map/index.vue
+++ b/pages/map/index.vue
@@ -17,9 +17,9 @@
           />
           <UButton
             size="sm"
-            color="amber"
+            :color="canEditActiveCrawl ? 'amber' : 'sky'"
             variant="soft"
-            icon="i-heroicons-map-20-solid"
+            :icon="canEditActiveCrawl ? 'i-heroicons-map-20-solid' : 'i-heroicons-eye-20-solid'"
             :label="crawlButtonLabel"
             @click="openCrawlBuilder"
           />
@@ -139,7 +139,7 @@
               @click="openSelectedVenueEvents"
             />
             <UButton
-              v-if="isLoggedIn"
+              v-if="showCrawlToggleButton"
               :color="selectedVenueOnActiveCrawl ? 'red' : 'amber'"
               variant="soft"
               :icon="selectedVenueOnActiveCrawl ? 'i-heroicons-minus-20-solid' : 'i-heroicons-plus-20-solid'"
@@ -237,6 +237,7 @@ const {
   setProgressAndSave,
   initialize: initializePubCrawl,
   errorMessage: crawlErrorMessage,
+  canEditActiveCrawl,
 } = usePubCrawl()
 
 const selectedCity = ref('')
@@ -255,16 +256,23 @@ let lastArrivalIndex: number | null = null
 
 const crawlSelectOptions = computed(() =>
   crawls.value.map((crawl) => ({
-    label: `${crawl.name} (${crawl.stopCount})`,
+    label: `${crawl.name} (${crawl.stopCount})${crawl.role === 'member' ? ' · invited' : ''}`,
     value: crawl.id,
   })),
 )
 
 const crawlButtonLabel = computed(() => {
-  if (!activeCrawl.value?.name) return 'Manage crawls'
+  const name = activeCrawl.value?.name
+  if (!canEditActiveCrawl.value) {
+    if (!name) return 'View crawls'
+    return crawls.value.length > 1
+      ? `View · ${crawls.value.length} lists`
+      : `View · ${name}`
+  }
+  if (!name) return 'Manage crawls'
   return crawls.value.length > 1
     ? `Manage · ${crawls.value.length} lists`
-    : `Manage · ${activeCrawl.value.name}`
+    : `Manage · ${name}`
 })
 
 const selectedVenueOnActiveCrawl = computed(() =>
@@ -278,6 +286,10 @@ const crawlToggleLabel = computed(() => {
   }
   return name ? `Add to ${name}` : 'Add to crawl'
 })
+
+const showCrawlToggleButton = computed(() =>
+  isLoggedIn.value && canEditActiveCrawl.value,
+)
 
 watch(
   () => activeCrawl.value?.id,
@@ -339,6 +351,10 @@ function showCrawlToggleMessage(message: string, isError = false) {
 
 async function toggleSelectedVenueOnCrawl() {
   if (!selectedVenue.value || crawlAddPending.value) return
+  if (!canEditActiveCrawl.value) {
+    showCrawlToggleMessage('Only the crawl creator can add or remove pubs.', true)
+    return
+  }
   crawlAddMessage.value = ''
   crawlAddMessageIsError.value = false
   crawlAddPending.value = true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Only the **pub crawl creator** can invite, edit, delete, reorder, add/remove pubs, or update progress. **Invited users can view** (and chat) only.

## Map
- Invitee toolbar: **View · [crawl]** (not Manage)
- Venue modal: no Add/Remove for invitees
- Auto check-in / progress updates: creator only

## Builder panel
- Invited lists marked **Invited**; owned lists **Yours**
- No delete / rename / reorder / remove stops for invitees
- View-only notice on shared active crawl
- Chat still available

## Dashboard (already)
- Invite / Mark complete / Delete: owner only

## Composable / API
- Client guards on add/remove/progress
- Server already rejects non-owner mutations with 403

Invitees can still: open the crawl, see the route on the map, and use chat.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f115d295-b0d1-4947-b408-4e43bc3859e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f115d295-b0d1-4947-b408-4e43bc3859e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

