### PR TITLE
Hide read notifications and improve crawl chat on mobile

### DIFF
--- a/components/crawl/CrawlChat.vue
+++ b/components/crawl/CrawlChat.vue
@@ -77,15 +77,12 @@
         type="submit"
         color="amber"
         size="md"
-        class="shrink-0 px-3 sm:px-4"
+        class="shrink-0"
         :loading="sending"
         :disabled="!draft.trim()"
         icon="i-heroicons-paper-airplane-20-solid"
-        :trailing="false"
-        aria-label="Send message"
-      >
-        <span class="sr-only sm:not-sr-only sm:ml-1">Send</span>
-      </UButton>
+        label="Send"
+      />
     </form>
   </div>
 </template>

--- a/components/crawl/CrawlChat.vue
+++ b/components/crawl/CrawlChat.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="flex h-full min-h-[22rem] flex-col">
-    <div class="border-b border-gray-200 px-1 pb-3 dark:border-gray-800">
+  <div class="flex h-full min-h-0 flex-col">
+    <div class="shrink-0 border-b border-gray-200 px-0.5 pb-2.5 dark:border-gray-800 sm:pb-3">
       <div class="flex flex-wrap items-center justify-between gap-2">
-        <h3 class="text-base font-semibold text-gray-900 dark:text-white">
+        <h3 class="truncate text-base font-semibold text-gray-900 dark:text-white">
           {{ crawlName }} chat
         </h3>
         <span
-          class="inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide"
+          class="inline-flex shrink-0 items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide"
           :class="realtimeConnected
             ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-200'
             : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300'"
@@ -18,14 +18,17 @@
           {{ realtimeConnected ? 'Live' : 'Connecting' }}
         </span>
       </div>
-      <p class="mt-0.5 text-xs text-gray-500">
+      <p class="mt-0.5 hidden text-xs text-gray-500 sm:block">
         Only the crawl creator and accepted members can see this conversation. Messages update in real time.
+      </p>
+      <p class="mt-0.5 text-xs text-gray-500 sm:hidden">
+        Members only · live updates
       </p>
     </div>
 
     <div
       ref="listEl"
-      class="min-h-0 flex-1 space-y-3 overflow-y-auto py-3 pr-1"
+      class="min-h-0 flex-1 space-y-2.5 overflow-y-auto overscroll-contain py-2.5 pr-0.5 sm:space-y-3 sm:py-3 sm:pr-1"
     >
       <div v-if="loading && !messages.length" class="text-sm text-gray-500">
         Loading chat…
@@ -36,17 +39,17 @@
       <div
         v-for="message in messages"
         :key="message.id"
-        class="rounded-lg px-3 py-2 text-sm"
+        class="rounded-lg px-2.5 py-2 text-sm sm:px-3"
         :class="message.userId === currentUserId
-          ? 'ml-8 bg-amber-50 text-amber-950 dark:bg-amber-950/40 dark:text-amber-100'
-          : 'mr-8 bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100'"
+          ? 'ml-6 bg-amber-50 text-amber-950 dark:bg-amber-950/40 dark:text-amber-100 sm:ml-10'
+          : 'mr-6 bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100 sm:mr-10'"
       >
-        <div class="mb-1 flex flex-wrap items-baseline justify-between gap-2 text-[11px]">
-          <span class="font-semibold">
-            {{ message.displayName }}
-            <span class="font-normal text-gray-500 dark:text-gray-400">@{{ message.username }}</span>
+        <div class="mb-1 flex flex-wrap items-baseline justify-between gap-x-2 gap-y-0.5 text-[11px]">
+          <span class="min-w-0 font-semibold">
+            <span class="truncate">{{ message.displayName }}</span>
+            <span class="font-normal text-gray-500 dark:text-gray-400"> @{{ message.username }}</span>
           </span>
-          <time class="text-gray-500 dark:text-gray-400" :datetime="message.createdAt">
+          <time class="shrink-0 text-gray-500 dark:text-gray-400" :datetime="message.createdAt">
             {{ formatTime(message.createdAt) }}
           </time>
         </div>
@@ -55,22 +58,34 @@
       <p v-if="errorMessage" class="text-sm text-red-600 dark:text-red-400">{{ errorMessage }}</p>
     </div>
 
-    <form class="mt-auto flex gap-2 border-t border-gray-200 pt-3 dark:border-gray-800" @submit.prevent="sendMessage">
+    <form
+      class="mt-auto flex shrink-0 gap-2 border-t border-gray-200 pt-2.5 dark:border-gray-800 sm:pt-3"
+      style="padding-bottom: max(0px, env(safe-area-inset-bottom))"
+      @submit.prevent="sendMessage"
+    >
       <UInput
         v-model="draft"
-        class="flex-1"
+        class="min-w-0 flex-1"
+        size="md"
         maxlength="2000"
         autocomplete="off"
-        placeholder="Write a message…"
+        enterkeyhint="send"
+        placeholder="Message…"
         :disabled="sending"
       />
       <UButton
         type="submit"
         color="amber"
+        size="md"
+        class="shrink-0 px-3 sm:px-4"
         :loading="sending"
         :disabled="!draft.trim()"
-        label="Send"
-      />
+        icon="i-heroicons-paper-airplane-20-solid"
+        :trailing="false"
+        aria-label="Send message"
+      >
+        <span class="sr-only sm:not-sr-only sm:ml-1">Send</span>
+      </UButton>
     </form>
   </div>
 </template>
@@ -108,12 +123,11 @@ let fallbackPollTimer: ReturnType<typeof setInterval> | null = null
 
 function formatTime(iso: string) {
   try {
-    return new Date(iso).toLocaleString(undefined, {
-      day: 'numeric',
-      month: 'short',
-      hour: '2-digit',
-      minute: '2-digit',
-    })
+    const date = new Date(iso)
+    const sameDay = new Date().toDateString() === date.toDateString()
+    return date.toLocaleString(undefined, sameDay
+      ? { hour: '2-digit', minute: '2-digit' }
+      : { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' })
   } catch {
     return iso
   }

--- a/components/crawl/CrawlRoutePreview.vue
+++ b/components/crawl/CrawlRoutePreview.vue
@@ -1,0 +1,77 @@
+<template>
+  <div class="overflow-hidden rounded-lg border border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-900/60">
+    <ClientOnly>
+      <div v-if="!hasToken" class="flex h-40 items-center justify-center px-4 text-center text-xs text-gray-500 sm:h-48">
+        Map preview unavailable (Mapbox token not configured).
+      </div>
+      <div v-else-if="!mapUrl" class="flex h-40 items-center justify-center px-4 text-center text-xs text-gray-500 sm:h-48">
+        {{ emptyLabel }}
+      </div>
+      <NuxtLink
+        v-else
+        to="/map"
+        class="group relative block focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+        :aria-label="`View ${crawlName} route on the map`"
+      >
+        <img
+          :src="mapUrl"
+          :alt="`${crawlName} route map`"
+          class="h-40 w-full object-cover sm:h-52"
+          width="640"
+          height="280"
+          loading="lazy"
+          decoding="async"
+        />
+        <div
+          class="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/55 to-transparent px-3 pb-2 pt-8"
+        >
+          <p class="truncate text-xs font-medium text-white">
+            {{ stopSummary }}
+          </p>
+        </div>
+      </NuxtLink>
+      <template #fallback>
+        <div class="h-40 animate-pulse bg-gray-200 dark:bg-gray-800 sm:h-52" aria-hidden="true" />
+      </template>
+    </ClientOnly>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { crawlStaticMapUrl, crawlStopCoordinates, type CrawlMapStop } from '@/utils/crawl-static-map'
+
+const props = defineProps<{
+  crawlName: string
+  stops?: CrawlMapStop[] | null
+  stopCount?: number
+}>()
+
+const mapboxToken = useMapboxToken()
+
+const hasToken = computed(() => Boolean(mapboxToken.value))
+
+const mapUrl = computed(() =>
+  crawlStaticMapUrl(props.stops, mapboxToken.value, 640, 280),
+)
+
+const coordCount = computed(() => crawlStopCoordinates(props.stops).length)
+
+const emptyLabel = computed(() => {
+  if ((props.stopCount || 0) > 0 && coordCount.value === 0) {
+    return 'Stops are missing map coordinates.'
+  }
+  return 'Add pubs on the map to see this route.'
+})
+
+const stopSummary = computed(() => {
+  const names = (props.stops || [])
+    .map((stop) => String(stop.venueName || '').trim())
+    .filter(Boolean)
+  if (!names.length) {
+    const n = props.stopCount || coordCount.value
+    return n ? `${n} stop${n === 1 ? '' : 's'}` : 'Route'
+  }
+  if (names.length <= 3) return names.join(' → ')
+  return `${names[0]} → … → ${names[names.length - 1]} (${names.length} stops)`
+})
+</script>

--- a/components/crawl/DashboardCard.vue
+++ b/components/crawl/DashboardCard.vue
@@ -78,6 +78,12 @@
         </div>
       </div>
 
+      <CrawlRoutePreview
+        :crawl-name="crawl.name"
+        :stops="crawl.stops"
+        :stop-count="crawl.stopCount"
+      />
+
       <div>
         <h4 class="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-500">Who’s on this crawl</h4>
         <ul v-if="crawl.members?.length" class="flex flex-wrap gap-2">
@@ -145,6 +151,12 @@ const props = defineProps<{
     role?: 'owner' | 'member'
     invitedBy?: { userId: string; username: string; displayName: string } | null
     owner?: { userId: string; username: string; displayName: string } | null
+    stops?: Array<{
+      venueName?: string | null
+      latitude?: number | null
+      longitude?: number | null
+      sortOrder?: number
+    }>
     members?: Array<{
       userId: string
       username: string

--- a/components/crawl/DashboardCard.vue
+++ b/components/crawl/DashboardCard.vue
@@ -99,9 +99,18 @@
       </div>
     </div>
 
-    <USlideover v-model="chatOpen">
-      <div class="flex h-full flex-col p-4">
-        <div class="mb-2 flex justify-end">
+    <USlideover
+      v-model="chatOpen"
+      :ui="{ width: 'w-screen max-w-full sm:max-w-md' }"
+    >
+      <div
+        class="flex h-[100dvh] max-h-[100dvh] flex-col px-3 pt-3 sm:h-full sm:max-h-none sm:p-4"
+        style="padding-bottom: max(0.75rem, env(safe-area-inset-bottom))"
+      >
+        <div class="mb-1 flex shrink-0 items-center justify-between gap-2 sm:mb-2 sm:justify-end">
+          <p class="truncate text-sm font-medium text-gray-700 dark:text-gray-200 sm:hidden">
+            {{ crawl.name }}
+          </p>
           <UButton
             color="gray"
             variant="ghost"

--- a/components/map/PubCrawlBuilder.vue
+++ b/components/map/PubCrawlBuilder.vue
@@ -176,7 +176,7 @@
         </div>
         <CrawlChat
           v-if="chatOpen && chatUserId"
-          class="rounded-lg border border-gray-200 p-3 dark:border-gray-800"
+          class="h-[min(55dvh,22rem)] rounded-lg border border-gray-200 p-2.5 dark:border-gray-800 sm:h-[min(50dvh,24rem)] sm:p-3"
           :crawl-id="activeCrawl.id"
           :crawl-name="activeCrawl.name"
           :current-user-id="chatUserId"

--- a/pages/pub-crawls/index.vue
+++ b/pages/pub-crawls/index.vue
@@ -78,17 +78,16 @@
         </UCard>
       </section>
 
-      <!-- Notifications -->
-      <section v-if="notifications.length" class="mb-8 space-y-2">
+      <!-- Notifications (unread only — Mark all read hides this section) -->
+      <section v-if="unreadNotifications.length" class="mb-8 space-y-2">
         <div class="flex items-center justify-between gap-2">
           <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-500">
             Notifications
-            <span v-if="unreadNotificationCount" class="ml-1 rounded bg-amber-100 px-1.5 py-0.5 text-amber-900">
-              {{ unreadNotificationCount }} new
+            <span class="ml-1 rounded bg-amber-100 px-1.5 py-0.5 text-amber-900">
+              {{ unreadNotifications.length }} new
             </span>
           </h2>
           <UButton
-            v-if="unreadNotificationCount"
             size="xs"
             color="gray"
             variant="link"
@@ -98,12 +97,9 @@
         </div>
         <ul class="space-y-2">
           <li
-            v-for="note in notifications.slice(0, 8)"
+            v-for="note in unreadNotifications.slice(0, 8)"
             :key="note.id"
-            class="rounded-md border px-3 py-2 text-sm"
-            :class="note.readAt
-              ? 'border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900'
-              : 'border-amber-300 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/40'"
+            class="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm dark:border-amber-800 dark:bg-amber-950/40"
           >
             <p class="font-medium text-gray-900 dark:text-white">{{ note.title }}</p>
             <p v-if="note.body" class="text-gray-600 dark:text-gray-400">{{ note.body }}</p>
@@ -296,6 +292,10 @@ const loaded = ref(false)
 const errorMessage = ref('')
 const respondingId = ref<string | null>(null)
 
+const unreadNotifications = computed(() =>
+  notifications.value.filter((note) => !note.readAt),
+)
+
 const inviteOpen = ref(false)
 const inviteCrawl = ref<CrawlCard | null>(null)
 const inviteQuery = ref('')
@@ -470,7 +470,8 @@ async function markNotificationsRead() {
       method: 'POST',
       body: { markAllRead: true },
     })
-    await loadDashboard()
+    notifications.value = []
+    unreadNotificationCount.value = 0
   } catch {
     /* ignore */
   }

--- a/pages/pub-crawls/index.vue
+++ b/pages/pub-crawls/index.vue
@@ -127,44 +127,48 @@
         </ul>
       </section>
 
-      <!-- Active -->
+      <!-- Your crawls (owned, incomplete) -->
       <section class="mb-8 space-y-3">
-        <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
-          {{ activeSectionTitle }}
-        </h2>
-        <CrawlDashboardCard
-          v-if="activeCrawl"
-          :crawl="activeCrawl"
-          :current-user-id="profile?.userId"
-          accent="emerald"
-          @invite="openInvite(activeCrawl)"
-          @complete="toggleComplete(activeCrawl, true)"
-          @reopen="toggleComplete(activeCrawl, false)"
-          @deleted="loadDashboard"
-        />
-        <p v-else class="text-sm text-gray-500">
-          No active crawl.
-          <NuxtLink to="/map" class="text-amber-700 hover:underline">Create one on the map</NuxtLink>
-          <template v-if="pendingInvites.length"> or accept an invite above.</template>
-        </p>
-      </section>
-
-      <!-- Other -->
-      <section class="mb-8 space-y-3">
-        <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Other crawls</h2>
-        <div v-if="otherCrawls.length" class="space-y-3">
+        <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Your crawls</h2>
+        <div v-if="yourCrawls.length" class="space-y-3">
           <CrawlDashboardCard
-            v-for="crawl in otherCrawls"
+            v-for="crawl in yourCrawls"
             :key="crawl.id"
             :crawl="crawl"
             :current-user-id="profile?.userId"
+            :accent="activeCrawl?.id === crawl.id ? 'emerald' : undefined"
             @invite="openInvite(crawl)"
             @complete="toggleComplete(crawl, true)"
             @reopen="toggleComplete(crawl, false)"
             @deleted="loadDashboard"
           />
         </div>
-        <p v-else class="text-sm text-gray-500">No other crawls right now.</p>
+        <p v-else class="text-sm text-gray-500">
+          No crawls of your own yet.
+          <NuxtLink to="/map" class="text-amber-700 hover:underline">Create one on the map</NuxtLink>
+        </p>
+      </section>
+
+      <!-- Shared with you (accepted invites, incomplete) -->
+      <section class="mb-8 space-y-3">
+        <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Shared with you</h2>
+        <div v-if="sharedCrawls.length" class="space-y-3">
+          <CrawlDashboardCard
+            v-for="crawl in sharedCrawls"
+            :key="crawl.id"
+            :crawl="crawl"
+            :current-user-id="profile?.userId"
+            :accent="activeCrawl?.id === crawl.id ? 'emerald' : undefined"
+            @invite="openInvite(crawl)"
+            @complete="toggleComplete(crawl, true)"
+            @reopen="toggleComplete(crawl, false)"
+            @deleted="loadDashboard"
+          />
+        </div>
+        <p v-else class="text-sm text-gray-500">
+          No shared crawls yet.
+          <template v-if="pendingInvites.length"> Accept an invite above to see it here.</template>
+        </p>
       </section>
 
       <!-- Completed -->
@@ -270,6 +274,12 @@ type CrawlCard = {
   owner?: Profile | null
   invitedBy?: Profile | null
   updatedAt: string
+  stops?: Array<{
+    venueName?: string | null
+    latitude?: number | null
+    longitude?: number | null
+    sortOrder?: number
+  }>
 }
 type PendingInvite = {
   id: string
@@ -296,6 +306,23 @@ const unreadNotifications = computed(() =>
   notifications.value.filter((note) => !note.readAt),
 )
 
+/** Incomplete owned crawls (active first). */
+const yourCrawls = computed(() => {
+  const ownedIncomplete = [
+    ...(activeCrawl.value?.role === 'owner' ? [activeCrawl.value] : []),
+    ...otherCrawls.value.filter((crawl) => crawl.role === 'owner'),
+  ]
+  return ownedIncomplete
+})
+
+/** Incomplete shared crawls (active first). */
+const sharedCrawls = computed(() => {
+  return [
+    ...(activeCrawl.value?.role === 'member' ? [activeCrawl.value] : []),
+    ...otherCrawls.value.filter((crawl) => crawl.role === 'member'),
+  ]
+})
+
 const inviteOpen = ref(false)
 const inviteCrawl = ref<CrawlCard | null>(null)
 const inviteQuery = ref('')
@@ -317,12 +344,7 @@ const pageSubtitle = computed(() => {
     const inviter = activeCrawl.value.invitedBy
     return `Shared crawl invited by ${inviter.displayName} (@${inviter.username}). You can view it, but only the creator can edit.`
   }
-  return 'Your active crawl, invites, and shared lists.'
-})
-
-const activeSectionTitle = computed(() => {
-  if (activeCrawl.value?.role === 'member') return 'Shared with you'
-  return 'Current active crawl'
+  return 'Your crawls, shared lists, and invites.'
 })
 
 function inviteIdForNotification(note: { type?: string; crawlId?: string | null; link?: string | null }) {

--- a/server/api/crawls/dashboard.get.ts
+++ b/server/api/crawls/dashboard.get.ts
@@ -51,7 +51,7 @@ export default defineEventHandler(async (event) => {
       orderBy: { createdAt: 'desc' },
     }),
     prisma.ukpubsNotification.findMany({
-      where: { userId: user.id },
+      where: { userId: user.id, readAt: null },
       orderBy: { createdAt: 'desc' },
       take: 30,
     }),
@@ -182,6 +182,6 @@ export default defineEventHandler(async (event) => {
       }
     }),
     notifications: notifications.map(serializeNotification),
-    unreadNotificationCount: notifications.filter((n) => !n.readAt).length,
+    unreadNotificationCount: notifications.length,
   }
 })

--- a/server/api/notifications/index.ts
+++ b/server/api/notifications/index.ts
@@ -7,13 +7,13 @@ export default defineEventHandler(async (event) => {
 
   if (event.method === 'GET') {
     const rows = await prisma.ukpubsNotification.findMany({
-      where: { userId: user.id },
+      where: { userId: user.id, readAt: null },
       orderBy: { createdAt: 'desc' },
       take: 40,
     })
     return {
       notifications: rows.map(serializeNotification),
-      unreadCount: rows.filter((n) => !n.readAt).length,
+      unreadCount: rows.length,
     }
   }
 

--- a/utils/crawl-static-map.ts
+++ b/utils/crawl-static-map.ts
@@ -1,0 +1,58 @@
+import { parseVenueCoord } from '@/utils/format-venue'
+
+export type CrawlMapStop = {
+  latitude?: unknown
+  longitude?: unknown
+  venueName?: string | null
+}
+
+/** Valid [lng, lat] pairs from crawl stops, in list order. */
+export function crawlStopCoordinates(stops: CrawlMapStop[] | null | undefined): [number, number][] {
+  if (!Array.isArray(stops)) return []
+  const out: [number, number][] = []
+  for (const stop of stops) {
+    const lat = parseVenueCoord(stop.latitude)
+    const lng = parseVenueCoord(stop.longitude)
+    if (lat == null || lng == null) continue
+    if (lat === 0 && lng === 0) continue
+    out.push([lng, lat])
+  }
+  return out
+}
+
+/**
+ * Mapbox Static Images URL zoomed to the crawl route (path + numbered pins).
+ * Uses `auto` framing so the camera fits all venues.
+ */
+export function crawlStaticMapUrl(
+  stops: CrawlMapStop[] | null | undefined,
+  token: string,
+  width = 640,
+  height = 280,
+): string | null {
+  if (!token) return null
+  // Cap overlays to keep URLs under Mapbox's practical length limit
+  const points = crawlStopCoordinates(stops).slice(0, 20)
+  if (!points.length) return null
+
+  const pins = points
+    .map(([lng, lat], index) => {
+      const label = Math.min(index + 1, 99)
+      return `pin-s-${label}+ea580c(${lng},${lat})`
+    })
+    .join(',')
+
+  let overlay = pins
+  if (points.length >= 2) {
+    const pathCoords = points.map(([lng, lat]) => `${lng},${lat}`).join(';')
+    overlay = `path-4+b45309-0.9(${pathCoords}),${pins}`
+  }
+
+  const size = `${Math.round(width)}x${Math.round(height)}@2x`
+  if (points.length === 1) {
+    const [lng, lat] = points[0]
+    return `https://api.mapbox.com/styles/v1/mapbox/streets-v11/static/${overlay}/${lng},${lat},14,0/${size}?access_token=${encodeURIComponent(token)}`
+  }
+
+  return `https://api.mapbox.com/styles/v1/mapbox/streets-v11/static/${overlay}/auto/${size}?padding=56&access_token=${encodeURIComponent(token)}`
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- **Mark all read** hides notifications: APIs return unread only, and marking all read clears the list immediately.
- **Crawl chat** is more usable on phones: full-width slideover, safer heights, tighter bubbles, and a constrained map-builder chat panel.
- **Dashboard route maps**: each crawl card on `/pub-crawls` shows a zoomed Mapbox static preview of its venues and route path.
- Dashboard sections are grouped as **Your crawls**, **Shared with you**, and **Completed crawls**.

## Test plan
- [ ] Open Pub Crawls with unread notifications → **Mark all read** → section disappears
- [ ] Open Chat from a crawl card on a narrow viewport → full-width panel works with keyboard
- [ ] `/pub-crawls` cards show a zoomed route map with numbered stops and a connecting path
- [ ] Crawls with no coordinates show an empty-state message instead of a broken image
- [ ] Your / Shared / Completed sections list the right crawls
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f115d295-b0d1-4947-b408-4e43bc3859e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f115d295-b0d1-4947-b408-4e43bc3859e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

